### PR TITLE
Create journey-tests.yaml

### DIFF
--- a/.github/workflows/journey-tests.yaml
+++ b/.github/workflows/journey-tests.yaml
@@ -1,0 +1,11 @@
+name: Journey Tests
+
+on:
+  workflow_dispatch:
+  workflow_run:
+    workflows: [ 'Publish' ]
+    types:
+      - completed
+jobs:
+  test:
+    uses: defra/apha-apps-perms-move-animal-uat/.github/workflows/run-tests.yaml@main


### PR DESCRIPTION
We believe this will trigger the UAT tests after a build - and turn red if the tests fail. 

This isn't ideal, since the artifact will already be published to ECR.  We're talking to CDP team about whether there's a better way to do this that genuinely blocks making a releasable artifact on journey test failure.