### PR TITLE
BAU: extract validator as a standardised function

### DIFF
--- a/src/server/common/page/model.js
+++ b/src/server/common/page/model.js
@@ -1,0 +1,10 @@
+/**
+ * @template Payload
+ * @template Data
+ * @typedef {{
+ *   clean: (payload: Payload) => Data,
+ *   validate: (data: Data) => ValidationResult
+ * }} Model<Payload, Data>
+ */
+
+/** @import {ValidationResult} from './validation.js' */

--- a/src/server/common/page/validation.js
+++ b/src/server/common/page/validation.js
@@ -1,0 +1,28 @@
+/**
+ * @typedef {{ isValid: boolean, errors: {[key:string]: string} }} ValidationResult
+ */
+
+/**
+ * @param {Schema} schema
+ * @param {object} value
+ * @returns {ValidationResult}
+ */
+export const validate = (schema, value) => {
+  const { error } = schema.validate(value, { abortEarly: false })
+
+  if (error === undefined) {
+    return { isValid: true, errors: {} }
+  } else {
+    const errors = error.details?.map((x) => [
+      x.context?.label ?? '',
+      x.message
+    ])
+
+    return {
+      isValid: false,
+      errors: Object.fromEntries(errors ?? [])
+    }
+  }
+}
+
+/** @import { Schema } from 'joi' */

--- a/src/server/common/page/validation.test.js
+++ b/src/server/common/page/validation.test.js
@@ -1,0 +1,32 @@
+import Joi from 'joi'
+import { validate } from './validation.js'
+
+describe('page validate', () => {
+  const schema = Joi.object({
+    a: Joi.string().required().messages({
+      'any.required': 'a should not be missing'
+    }),
+    b: Joi.string().max(5).messages({
+      'string.max': 'b should not be too long'
+    })
+  })
+
+  it('should take a Joi schema, input data & returna validation result', () => {
+    expect(validate(schema, { b: '123' })).toEqual({
+      isValid: false,
+      errors: {
+        a: 'a should not be missing'
+      }
+    })
+  })
+
+  it('should run validation against all fields', () => {
+    expect(validate(schema, { b: '123456' })).toEqual({
+      isValid: false,
+      errors: {
+        b: 'b should not be too long',
+        a: 'a should not be missing'
+      }
+    })
+  })
+})

--- a/src/server/cph-number/controller.js
+++ b/src/server/cph-number/controller.js
@@ -32,7 +32,7 @@ export const postController = {
     const { cphNumber } = /** @type {CphNumberPayload} */ (req.payload)
     // Remove whitespace from cphNumber
     const input = cphNumber ? cphNumber.replace(/\s+/g, '') : cphNumber
-    const [isValid, message] = validator(input)
+    const { isValid, errors } = validator({ cphNumber: input })
 
     if (!isValid) {
       req.yar.clear('cphNumber')
@@ -43,7 +43,7 @@ export const postController = {
           value: input
         },
         errorMessage: {
-          text: message
+          text: errors.cphNumber
         }
       })
     }

--- a/src/server/cph-number/validator.js
+++ b/src/server/cph-number/validator.js
@@ -1,20 +1,26 @@
+import { validate } from '../common/page/validation.js'
+import Joi from 'joi'
+
+const emptyMessage = 'Enter the farm or premises CPH number'
+const malformedMessage =
+  'Enter the CPH number in the correct format, for example, 12/345/6789'
+const cphPattern = /([0-9]{2})\/([0-9]{3})\/([0-9]{4})/
+const requiredLength = 11
+
+const schema = Joi.object({
+  cphNumber: Joi.string()
+    .required()
+    .pattern(cphPattern)
+    .max(requiredLength)
+    .messages({
+      'any.required': emptyMessage,
+      'string.empty': emptyMessage,
+      'string.pattern.base': malformedMessage,
+      'string.max': malformedMessage
+    })
+})
+
 /**
- * @returns [ boolean | string | null ]
+ * @params {{cphNumber: string | undefined}}
  */
-export default (input) => {
-  const valid = /([0-9]{2})\/([0-9]{3})\/([0-9]{4})/g
-  const requiredLength = 11
-
-  if (!input) {
-    return [false, 'Enter the farm or premises CPH number']
-  }
-
-  if (input && (!valid.test(input) || input.length !== requiredLength)) {
-    return [
-      false,
-      'Enter the CPH number in the correct format, for example, 12/345/6789'
-    ]
-  }
-
-  return [true, null]
-}
+export default (input) => validate(schema, input)

--- a/src/server/on-off-farm/controller.js
+++ b/src/server/on-off-farm/controller.js
@@ -1,3 +1,5 @@
+import validator from './validator.js'
+
 const pageTitle = 'Are you moving the cattle on or off your farm or premises?'
 const pageHeading = 'Are you moving the cattle on or off your farm or premises?'
 const indexView = 'on-off-farm/index.njk'
@@ -28,13 +30,14 @@ export const onOffFarmGetController = {
 export const onOffFarmPostController = {
   handler(req, res) {
     const { onOffFarm } = /** @type {OnOffFarmPayload} */ (req.payload)
+    const { isValid, errors } = validator({ onOffFarm })
 
-    if (!onOffFarm) {
+    if (!isValid) {
       return res.view(indexView, {
         pageTitle: `Error: ${pageTitle}`,
         heading: pageHeading,
         errorMessage: {
-          text: 'Select if you are moving cattle on or off your farm or premises'
+          text: errors.onOffFarm
         }
       })
     }
@@ -46,14 +49,6 @@ export const onOffFarmPostController = {
         return res.redirect('/cph-number')
       case 'on':
         return res.redirect('/exit-page')
-      default:
-        return res.view(indexView, {
-          pageTitle: `Error: ${pageTitle}`,
-          heading: pageHeading,
-          errorMessage: {
-            text: 'Select if you are moving cattle on or off your farm or premises'
-          }
-        })
     }
   }
 }

--- a/src/server/on-off-farm/validator.js
+++ b/src/server/on-off-farm/validator.js
@@ -1,0 +1,14 @@
+import { validate } from '../common/page/validation.js'
+import Joi from 'joi'
+
+const emptyMessage =
+  'Select if you are moving cattle on or off your farm or premises'
+
+const schema = Joi.object({
+  onOffFarm: Joi.string().required().allow('on', 'off').messages({
+    'any.required': emptyMessage,
+    'string.empty': emptyMessage
+  })
+})
+
+export default (input) => validate(schema, input)

--- a/src/server/origin-address/validator.js
+++ b/src/server/origin-address/validator.js
@@ -1,4 +1,6 @@
 import Joi from 'joi'
+import { validate } from '../common/page/validation.js'
+import _ from 'lodash'
 
 const postcodeRegex = /^[a-z]{1,2}\d[a-z\d]?\s*\d[a-z]{2}$/i
 
@@ -49,20 +51,12 @@ const addressSchema = Joi.object({
 
 /**
  * @param {OriginAddress} originAddress
- * @returns {{isValid: boolean, errors: object}}
  */
 export default (originAddress) => {
-  const result = addressSchema
-    .options({ abortEarly: false })
-    .validate(originAddress)
-  const errors = result.error?.details.map(({ context, message }) => [
-    /** @type string */ (context?.key),
-    { text: message }
-  ])
-
+  const { isValid, errors } = validate(addressSchema, originAddress)
   return {
-    isValid: result.error === undefined,
-    errors: errors && Object.fromEntries(errors)
+    isValid,
+    errors: _.mapValues(errors, (text) => ({ text }))
   }
 }
 
@@ -74,4 +68,8 @@ export default (originAddress) => {
  *  addressCounty ?: string;
  *  addressPostcode: string;
  * }} OriginAddress
+ */
+
+/**
+ * @import {ValidationResult} from'../common/page/validation.js'
  */


### PR DESCRIPTION
We're going to have to revalidate pages in a number of contexts:

* on initial submission
* when on the 'check answers' page
* when on the task list (e.g. a task is only complete if it has a complete suite of valid answers)
* when on final declare & submit page

Starting to move towards a uniform interface that can validate a form submission or state is a first step towards making that easier.