### PR TITLE
BAU: rename browserstack project

### DIFF
--- a/user-journey-tests/wdio.browserstack.conf.js
+++ b/user-journey-tests/wdio.browserstack.conf.js
@@ -99,7 +99,7 @@ export const config = merge(wdioConf, {
       {
         testObservability: true, // Disable if you do not want to use the browserstack test observer functionality
         testObservabilityOptions: {
-          projectName: 'apha-apps-perms-move-animal-uat',
+          projectName: 'apha-apps-perms-move-animal-ui',
           buildName: 'apha-test-run'
         },
         acceptInsecureCerts: true,


### PR DESCRIPTION
Now that we've merged our UI & UAT repos, it's more natural to call this project UI than UAT in browserstack.