### PR TITLE
DSFAAP-577: filter payload in answer model

### DIFF
--- a/src/server/common/model/answer/address.js
+++ b/src/server/common/model/answer/address.js
@@ -98,7 +98,7 @@ export class Address extends AnswerModel {
     return validateAnswerAgainstSchema(addressPayloadSchema, this._data ?? {})
   }
 
-  extractFields({
+  _extractFields({
     addressLine1,
     addressLine2,
     addressTown,

--- a/src/server/common/model/answer/address.js
+++ b/src/server/common/model/answer/address.js
@@ -79,6 +79,7 @@ export class Address extends AnswerModel {
 
   get html() {
     return Object.values(this.value ?? [])
+      .filter((line) => line !== undefined)
       .filter((line) => {
         const trimmed = line.trim()
         return trimmed.length > 0
@@ -95,6 +96,22 @@ export class Address extends AnswerModel {
 
   validate() {
     return validateAnswerAgainstSchema(addressPayloadSchema, this._data ?? {})
+  }
+
+  extractFields({
+    addressLine1,
+    addressLine2,
+    addressTown,
+    addressCounty,
+    addressPostcode
+  }) {
+    return {
+      addressLine1,
+      addressLine2,
+      addressTown,
+      addressCounty,
+      addressPostcode
+    }
   }
 
   /**

--- a/src/server/common/model/answer/address.js
+++ b/src/server/common/model/answer/address.js
@@ -79,7 +79,6 @@ export class Address extends AnswerModel {
 
   get html() {
     return Object.values(this.value ?? [])
-      .filter((line) => line !== undefined)
       .filter((line) => {
         const trimmed = line.trim()
         return trimmed.length > 0
@@ -107,9 +106,9 @@ export class Address extends AnswerModel {
   }) {
     return {
       addressLine1,
-      addressLine2,
+      ...(addressLine2 !== undefined && { addressLine2 }),
       addressTown,
-      addressCounty,
+      ...(addressCounty !== undefined && { addressCounty }),
       addressPostcode
     }
   }

--- a/src/server/common/model/answer/address.test.js
+++ b/src/server/common/model/answer/address.test.js
@@ -8,6 +8,15 @@ const validAddress = {
   addressPostcode: 'RG24 8RR'
 }
 
+describe('Address.new', () => {
+  it('should strip away any irrelevant values', () => {
+    const payload = { ...validAddress, nextPage: '/other/page' }
+    const address = new Address(payload)
+
+    expect(address._data).toEqual(validAddress)
+  })
+})
+
 describe('Address.validate', () => {
   it('should return true for valid address', () => {
     const address = new Address(validAddress)

--- a/src/server/common/model/answer/address.test.js
+++ b/src/server/common/model/answer/address.test.js
@@ -15,6 +15,17 @@ describe('Address.new', () => {
 
     expect(address._data).toEqual(validAddress)
   })
+
+  it('should graceully handle optional values', () => {
+    const validAddressWithOptionalsMissing = {
+      addressLine1: validAddress.addressLine1,
+      addressTown: validAddress.addressTown,
+      addressPostcode: validAddress.addressPostcode
+    }
+    const address = new Address(validAddressWithOptionalsMissing)
+
+    expect(address._data).toEqual(validAddressWithOptionalsMissing)
+  })
 })
 
 describe('Address.validate', () => {

--- a/src/server/common/model/answer/answer-model.js
+++ b/src/server/common/model/answer/answer-model.js
@@ -36,11 +36,11 @@ export class AnswerModel {
   }
 
   /**
-   * @param {Payload} data
+   * @param {Payload} _data
    * @returns {Payload}
    */
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  _extractFields(data) {
+  _extractFields(_data) {
     throw new NotImplementedError()
   }
 

--- a/src/server/common/model/answer/answer-model.js
+++ b/src/server/common/model/answer/answer-model.js
@@ -20,7 +20,7 @@ export class AnswerModel {
    * @param {Payload | undefined } [data]
    */
   constructor(data) {
-    this._data = data
+    this._data = data === undefined ? undefined : this.extractFields(data)
     Object.seal(this)
   }
 
@@ -36,6 +36,15 @@ export class AnswerModel {
   }
 
   /**
+   * @param {Payload} data
+   * @returns {Payload}
+   */
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  extractFields(data) {
+    throw new NotImplementedError()
+  }
+
+  /**
    * @returns {AnswerValidationResult}
    */
   validate() {
@@ -47,17 +56,14 @@ export class AnswerModel {
     throw new NotImplementedError()
   }
 
-  /* eslint-disable @typescript-eslint/no-unused-vars */
-
   /**
    * @param {unknown} _data
    * @returns {unknown}
    */
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   static fromState(_data) {
     throw new NotImplementedError()
   }
-
-  /* eslint-enable @typescript-eslint/no-unused-vars */
 }
 
 /**

--- a/src/server/common/model/answer/answer-model.js
+++ b/src/server/common/model/answer/answer-model.js
@@ -20,7 +20,7 @@ export class AnswerModel {
    * @param {Payload | undefined } [data]
    */
   constructor(data) {
-    this._data = data === undefined ? undefined : this.extractFields(data)
+    this._data = data === undefined ? undefined : this._extractFields(data)
     Object.seal(this)
   }
 
@@ -40,7 +40,7 @@ export class AnswerModel {
    * @returns {Payload}
    */
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  extractFields(data) {
+  _extractFields(data) {
     throw new NotImplementedError()
   }
 

--- a/src/server/common/model/answer/answer-model.test.js
+++ b/src/server/common/model/answer/answer-model.test.js
@@ -30,7 +30,7 @@ describe('AnswerModel', () => {
 
   it('should seal the object to prevent property additions or deletions', () => {
     class AnswerModelBasic extends AnswerModel {
-      extractFields(data) {
+      _extractFields(data) {
         return data
       }
     }

--- a/src/server/common/model/answer/answer-model.test.js
+++ b/src/server/common/model/answer/answer-model.test.js
@@ -27,16 +27,4 @@ describe('AnswerModel', () => {
   it('should throw NotImplementedError when fromState is called', () => {
     expect(() => AnswerModel.fromState({})).toThrow(notImplementedError)
   })
-
-  it('should seal the object to prevent property additions or deletions', () => {
-    answer = new AnswerModel({ key: 'value' })
-
-    expect(() => {
-      answer.something = 'should fail'
-    }).toThrow()
-
-    expect(() => {
-      delete answer._data
-    }).toThrow()
-  })
 })

--- a/src/server/common/model/answer/answer-model.test.js
+++ b/src/server/common/model/answer/answer-model.test.js
@@ -27,4 +27,21 @@ describe('AnswerModel', () => {
   it('should throw NotImplementedError when fromState is called', () => {
     expect(() => AnswerModel.fromState({})).toThrow(notImplementedError)
   })
+
+  it('should seal the object to prevent property additions or deletions', () => {
+    class AnswerModelBasic extends AnswerModel {
+      extractFields(data) {
+        return data
+      }
+    }
+    answer = new AnswerModelBasic({ key: 'value' })
+
+    expect(() => {
+      answer.something = 'should fail'
+    }).toThrow()
+
+    expect(() => {
+      delete answer._data
+    }).toThrow()
+  })
 })

--- a/src/server/common/model/answer/confirmation/confirmation.js
+++ b/src/server/common/model/answer/confirmation/confirmation.js
@@ -48,7 +48,7 @@ export class Confirmation extends AnswerModel {
     })
   }
 
-  extractFields({ confirmation }) {
+  _extractFields({ confirmation }) {
     return { confirmation }
   }
 

--- a/src/server/common/model/answer/confirmation/confirmation.js
+++ b/src/server/common/model/answer/confirmation/confirmation.js
@@ -48,6 +48,10 @@ export class Confirmation extends AnswerModel {
     })
   }
 
+  extractFields({ confirmation }) {
+    return { confirmation }
+  }
+
   /**
    * @param {ConfirmationData | undefined} state
    * @returns {Confirmation}

--- a/src/server/common/model/answer/confirmation/confirmation.test.js
+++ b/src/server/common/model/answer/confirmation/confirmation.test.js
@@ -1,6 +1,17 @@
 import { Confirmation } from './confirmation.js'
 
 describe('#ConfirmationModel', () => {
+  describe('Confirmation.new', () => {
+    it('should strip away any irrelevant values', () => {
+      const validConfirmation = { confirmation: ['confirm', 'other'] }
+
+      const payload = { ...validConfirmation, nextPage: '/other/page' }
+      const onOffFarm = new Confirmation(payload)
+
+      expect(onOffFarm._data).toEqual(validConfirmation)
+    })
+  })
+
   describe('validate', () => {
     it('should return valid when only confirmed', () => {
       const confirmation = new Confirmation({ confirmation: ['confirm'] })

--- a/src/server/common/model/answer/confirmation/confirmation.test.js
+++ b/src/server/common/model/answer/confirmation/confirmation.test.js
@@ -6,9 +6,9 @@ describe('#ConfirmationModel', () => {
       const validConfirmation = { confirmation: ['confirm', 'other'] }
 
       const payload = { ...validConfirmation, nextPage: '/other/page' }
-      const onOffFarm = new Confirmation(payload)
+      const confirmation = new Confirmation(payload)
 
-      expect(onOffFarm._data).toEqual(validConfirmation)
+      expect(confirmation._data).toEqual(validConfirmation)
     })
   })
 

--- a/src/server/common/model/answer/cph-number.js
+++ b/src/server/common/model/answer/cph-number.js
@@ -48,7 +48,7 @@ export class CphNumber extends AnswerModel {
     return validateAnswerAgainstSchema(cphNumberPayloadSchema, this._data ?? {})
   }
 
-  extractFields({ cphNumber }) {
+  _extractFields({ cphNumber }) {
     return { cphNumber }
   }
 

--- a/src/server/common/model/answer/cph-number.js
+++ b/src/server/common/model/answer/cph-number.js
@@ -48,6 +48,10 @@ export class CphNumber extends AnswerModel {
     return validateAnswerAgainstSchema(cphNumberPayloadSchema, this._data ?? {})
   }
 
+  extractFields({ cphNumber }) {
+    return { cphNumber }
+  }
+
   /**
    * @param {CphNumberData | undefined} state
    * @returns {CphNumber}

--- a/src/server/common/model/answer/cph-number.test.js
+++ b/src/server/common/model/answer/cph-number.test.js
@@ -4,6 +4,15 @@ const validCphNumberPayload = {
   cphNumber: '12/456/7899'
 }
 
+describe('CphNumber.new', () => {
+  it('should strip away any irrelevant values', () => {
+    const payload = { ...validCphNumberPayload, nextPage: '/other/page' }
+    const cphNumber = new CphNumber(payload)
+
+    expect(cphNumber._data).toEqual(validCphNumberPayload)
+  })
+})
+
 describe('#CphNumber.validate', () => {
   it('should return true for valid cphNumber', () => {
     const cphNumber = new CphNumber(validCphNumberPayload)

--- a/src/server/common/model/answer/email-address.js
+++ b/src/server/common/model/answer/email-address.js
@@ -51,7 +51,7 @@ export class EmailAddress extends AnswerModel {
     return validateAnswerAgainstSchema(emailAddressPayloadSchema, this._data)
   }
 
-  extractFields({ emailAddress }) {
+  _extractFields({ emailAddress }) {
     return { emailAddress }
   }
 

--- a/src/server/common/model/answer/email-address.js
+++ b/src/server/common/model/answer/email-address.js
@@ -51,6 +51,10 @@ export class EmailAddress extends AnswerModel {
     return validateAnswerAgainstSchema(emailAddressPayloadSchema, this._data)
   }
 
+  extractFields({ emailAddress }) {
+    return { emailAddress }
+  }
+
   /**
    * @param {EmailAddressData | undefined} state
    * @returns {EmailAddress}

--- a/src/server/common/model/answer/email-address.test.js
+++ b/src/server/common/model/answer/email-address.test.js
@@ -31,6 +31,15 @@ const invalidEmailAddresses = [
 ]
 
 describe('EmailAddress', () => {
+  describe('new', () => {
+    it('should strip away any irrelevant values', () => {
+      const payload = { ...validEmailAddressPayload, nextPage: '/other/page' }
+      const emailAddress = new EmailAddress(payload)
+
+      expect(emailAddress._data).toEqual(validEmailAddressPayload)
+    })
+  })
+
   describe('validate', () => {
     validEmailAddresses.forEach((email) => {
       it(`should return true for valid email address ${email}`, () => {

--- a/src/server/common/model/answer/on-off-farm.js
+++ b/src/server/common/model/answer/on-off-farm.js
@@ -57,7 +57,7 @@ export class OnOffFarm extends AnswerModel {
     return validateAnswerAgainstSchema(onOffFarmPayloadSchema, this._data ?? {})
   }
 
-  extractFields({ onOffFarm }) {
+  _extractFields({ onOffFarm }) {
     return { onOffFarm }
   }
 }

--- a/src/server/common/model/answer/on-off-farm.js
+++ b/src/server/common/model/answer/on-off-farm.js
@@ -56,4 +56,8 @@ export class OnOffFarm extends AnswerModel {
   validate() {
     return validateAnswerAgainstSchema(onOffFarmPayloadSchema, this._data ?? {})
   }
+
+  extractFields({ onOffFarm }) {
+    return { onOffFarm }
+  }
 }

--- a/src/server/common/model/answer/on-off-farm.test.js
+++ b/src/server/common/model/answer/on-off-farm.test.js
@@ -6,6 +6,15 @@ const validOnOffRadio = {
   onOffFarm: 'on'
 }
 
+describe('OnOffFarm.new', () => {
+  it('should strip away any irrelevant values', () => {
+    const payload = { ...validOnOffRadio, nextPage: '/other/page' }
+    const onOffFarm = new OnOffFarm(payload)
+
+    expect(onOffFarm._data).toEqual(validOnOffRadio)
+  })
+})
+
 describe('#OnOffFarm.validate', () => {
   test('should return true for on', () => {
     const { isValid, errors } = new OnOffFarm({

--- a/src/server/common/model/section/validation.test.js
+++ b/src/server/common/model/section/validation.test.js
@@ -1,21 +1,29 @@
 import { validateSection } from './validation.js'
+import { AnswerModel } from '../answer/answer-model.js'
 
-const baseMockAnswer = {
-  toState: jest.fn(),
-  value: 'value',
-  html: '',
-  _data: {}
+class MockAnswer extends AnswerModel {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  extractFields(data) {
+    return data
+  }
 }
 
-const validAnswer = {
-  ...baseMockAnswer,
-  validate: jest.fn().mockReturnValue({ isValid: true })
+class ValidAnswer extends MockAnswer {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  validate(_) {
+    return { isValid: true, errors: {} }
+  }
 }
 
-const invalidAnswer = {
-  ...baseMockAnswer,
-  validate: jest.fn().mockReturnValue({ isValid: false })
+class InvalidAnswer extends MockAnswer {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  validate(_) {
+    return { isValid: false, errors: { field1: { text: 'Invalid' } } }
+  }
 }
+const validAnswer = new ValidAnswer()
+
+const invalidAnswer = new InvalidAnswer()
 
 describe('validateSection', () => {
   it('should return isValid as true when all answers are valid', () => {
@@ -46,16 +54,8 @@ describe('validateSection', () => {
 
   it('should return the correct validation result for each answer', () => {
     const data = {
-      answer1: {
-        ...baseMockAnswer,
-        validate: jest.fn().mockReturnValue({ isValid: true, errors: {} })
-      },
-      answer2: {
-        ...baseMockAnswer,
-        validate: jest
-          .fn()
-          .mockReturnValue({ isValid: false, errors: { field1: 'Invalid' } })
-      }
+      answer1: validAnswer,
+      answer2: invalidAnswer
     }
 
     const { isValid, result } = validateSection(data)
@@ -64,7 +64,7 @@ describe('validateSection', () => {
     expect(result.answer1).toEqual({ isValid: true, errors: {} })
     expect(result.answer2).toEqual({
       isValid: false,
-      errors: { field1: 'Invalid' }
+      errors: { field1: { text: 'Invalid' } }
     })
   })
 })

--- a/src/server/common/model/section/validation.test.js
+++ b/src/server/common/model/section/validation.test.js
@@ -3,7 +3,7 @@ import { AnswerModel } from '../answer/answer-model.js'
 
 class MockAnswer extends AnswerModel {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  extractFields(data) {
+  _extractFields(data) {
     return data
   }
 }

--- a/user-journey-tests/helpers/testHelpers/checkAnswers.js
+++ b/user-journey-tests/helpers/testHelpers/checkAnswers.js
@@ -1,3 +1,4 @@
+import checkAnswersPage from '../../page-objects/origin/checkAnswersPage.js'
 import newAddressPage from '../../page-objects/origin/newAddressPage.js'
 import parishHoldingNumberPage from '../../page-objects/origin/parishHoldingNumberPage.js'
 import toFromFarmPage from '../../page-objects/origin/toFromFarmPage.js'
@@ -59,11 +60,16 @@ export const validateAndAdjustAddress = async (
     postcode
   })
 
-  await validateElementVisibleAndText(valueElement, lineOne)
-  await validateElementVisibleAndText(valueElement, lineTwo)
-  await validateElementVisibleAndText(valueElement, townOrCity)
-  await validateElementVisibleAndText(valueElement, county)
-  await validateElementVisibleAndText(valueElement, postcode)
+  // Expected text must be kept to the left of the page to ensure accuracy in the check
+  const elementText = await checkAnswersPage.addressValue
+    .getHTML(false)
+    .then((text) => text.replace(/<br\s*\/?>/g, '\n').trim())
+  const expectedText = `${lineOne}
+${lineTwo}
+${townOrCity}
+${county}
+${postcode}`
+  expect(elementText).toBe(expectedText)
 }
 
 export const validateAndAdjustEmail = async (


### PR DESCRIPTION
To ensure only the payload fields we care about are captured in the state, we need to filter them down. 

Otherwise we'll capture things like nextPage & potentially show them to users.