### PR TITLE
DSFAAP-583: section pages updates

### DIFF
--- a/src/server/common/model/section/origin.js
+++ b/src/server/common/model/section/origin.js
@@ -1,11 +1,7 @@
 import { SectionModel } from '../section/section-model/index.js'
-import { CphNumber } from '../answer/cph-number.js'
-import { Address } from '../answer/address.js'
-
-import { OnOffFarm } from '../answer/on-off-farm.js'
-import { OnOffFarmPage } from '../../../origin/on-off-farm/index.js'
-import { CphNumberPage } from '../../../origin/cph-number/index.js'
-import { OriginAddressPage } from '../../../origin/address/index.js'
+import { onOffFarmPage } from '../../../origin/on-off-farm/index.js'
+import { cphNumberPage } from '../../../origin/cph-number/index.js'
+import { originAddressPage } from '../../../origin/address/index.js'
 
 /**
  * export @typedef {{
@@ -19,7 +15,7 @@ import { OriginAddressPage } from '../../../origin/address/index.js'
  */
 
 export class Origin extends SectionModel {
-  firstPage = new OnOffFarmPage()
+  firstPage = onOffFarmPage
 
   get onOffFarm() {
     return this._data?.onOffFarm.answer
@@ -40,16 +36,16 @@ export class Origin extends SectionModel {
   static fromState(state) {
     return new Origin({
       onOffFarm: {
-        page: new OnOffFarmPage(),
-        answer: OnOffFarm.fromState(state?.onOffFarm)
+        page: onOffFarmPage,
+        answer: onOffFarmPage.Answer.fromState(state?.onOffFarm)
       },
       cphNumber: {
-        page: new CphNumberPage(),
-        answer: CphNumber.fromState(state?.cphNumber)
+        page: cphNumberPage,
+        answer: cphNumberPage.Answer.fromState(state?.cphNumber)
       },
       address: {
-        page: new OriginAddressPage(),
-        answer: Address.fromState(state?.address)
+        page: originAddressPage,
+        answer: originAddressPage.Answer.fromState(state?.address)
       }
     })
   }

--- a/src/server/common/model/section/section-model/section-model-updated.js
+++ b/src/server/common/model/section/section-model/section-model-updated.js
@@ -30,6 +30,9 @@ export class SectionModelUpdated {
     return this._data
   }
 
+  /**
+   * returns {QuestionPage[]}
+   */
   get pages() {
     const pages = []
 
@@ -40,6 +43,10 @@ export class SectionModelUpdated {
       const currPage = this._data[page.questionKey]
 
       pages.push(page)
+
+      if (!currPage.answer.validate().isValid) {
+        break
+      }
 
       page = page.nextPage(currPage.answer)
     }

--- a/src/server/common/model/section/section-model/section-model-updated.js
+++ b/src/server/common/model/section/section-model/section-model-updated.js
@@ -33,7 +33,7 @@ export class SectionModelUpdated {
   get pages() {
     const pages = []
 
-    /** @type {QuestionPage} */
+    /** @type {Page} */
     let page = this._data[this.firstPage.questionKey].page
 
     while (page instanceof QuestionPage) {
@@ -41,7 +41,7 @@ export class SectionModelUpdated {
 
       pages.push(page)
 
-      page = /** @type {QuestionPage} */ (page.nextPage(currPage.answer))
+      page = page.nextPage(currPage.answer)
     }
 
     return pages

--- a/src/server/common/model/section/section-model/section-model-updated.test.js
+++ b/src/server/common/model/section/section-model/section-model-updated.test.js
@@ -2,6 +2,7 @@ import { CphNumberPage } from '~/src/server/origin/cph-number/index.js'
 import { OnOffFarmPage } from '~/src/server/origin/on-off-farm/index.js'
 import { OnOffFarm } from '~/src/server/common/model/answer/on-off-farm.js'
 import { Origin } from '../origin.js'
+import { CphNumber } from '../../answer/cph-number.js'
 
 /** @import {OnOffFarmData} from '~/src/server/common/model/answer/on-off-farm.js' */
 
@@ -29,7 +30,7 @@ const exitState = {
   address: validAddress // this is unreachable in the journey, because we will have exited already
 }
 
-describe('SectionModel.value', () => {
+describe('SectionModel.pages', () => {
   it('should short-circuit on an exit page', () => {
     const origin = Origin.fromState(exitState)
     const pages = origin.pages
@@ -38,6 +39,22 @@ describe('SectionModel.value', () => {
     expect(pages.at(0)).toBeInstanceOf(OnOffFarmPage)
     expect(origin[pages.at(0)?.questionKey ?? 'invalid']).toBeInstanceOf(
       OnOffFarm
+    )
+  })
+
+  it('should short-circuit on a page with an invalid answer', () => {
+    const origin = Origin.fromState(invalidState)
+    const pages = origin.pages
+
+    expect(pages).toHaveLength(2)
+    expect(pages.at(0)).toBeInstanceOf(OnOffFarmPage)
+    expect(origin[pages.at(0)?.questionKey ?? 'invalid']).toBeInstanceOf(
+      OnOffFarm
+    )
+
+    expect(pages.at(1)).toBeInstanceOf(CphNumberPage)
+    expect(origin[pages.at(1)?.questionKey ?? 'invalid']).toBeInstanceOf(
+      CphNumber
     )
   })
 })


### PR DESCRIPTION
[DSFAAP-583: remove unneeded casting](https://github.com/DEFRA/apha-apps-perms-move-animal-ui/commit/31fe47525d1293ff2b1d69b2e47f1ba72892deee)

The page returned by next page could by any instance of Page - e.g. a
summary, exit or question page.

[DSFAAP-583: short-circuit page generation on invalid answer](https://github.com/DEFRA/apha-apps-perms-move-animal-ui/commit/b3519d0377bc943d43a0ae0685fae572098c9baa)

If a user has submitted an invalid answer at any point in the journey,
then there is no well defined output for the nextPage function on a
QuestionPage.

e.g. if you were to not have selected an input to 'Email' or 'Post' for
your licence delivery preference, then that page wouldn't be able to
calculate a next page.


[DSFAAP-583: source Answer class from question page](https://github.com/DEFRA/apha-apps-perms-move-animal-ui/pull/71/commits/083027f91e0262d02b1fe03b08538673f075889c)

The QuestionPage 'owns' which answer is relevant to it. If we were to
want to change the Answer class, then we wouldn't want to edit that in
the section class as well.