### PR TITLE
BAU: refactor question pages to return full payload needed for check-answers page

### DIFF
--- a/src/server/common/controller/summary-page-controller/SummaryPageController.js
+++ b/src/server/common/controller/summary-page-controller/SummaryPageController.js
@@ -57,13 +57,13 @@ export class SummaryPageController {
       )
     }
 
-    const items = section.questionPages.map((visitedPage) => ({
-      key: visitedPage.question,
-      value: section[visitedPage.questionKey].html,
-      url: `${visitedPage.urlPath}?redirect_uri=/${this.page.urlKey ?? this.page.sectionKey}/check-answers`,
-      visuallyHiddenKey: visitedPage.question,
+    const items = section.questionPageAnswers.map(({ page, answer }) => ({
+      key: page.question,
+      value: answer.html,
+      url: `${page.urlPath}?redirect_uri=/${this.page.urlKey ?? this.page.sectionKey}/check-answers`,
+      visuallyHiddenKey: page.question,
       attributes: {
-        'data-testid': `${visitedPage.questionKey}-change-link`
+        'data-testid': `${page.questionKey}-change-link`
       }
     }))
 

--- a/src/server/common/model/section/section-model/section-model.js
+++ b/src/server/common/model/section/section-model/section-model.js
@@ -62,7 +62,7 @@ export class SectionModel {
    * @returns {PageAnswer[]}
    */
   get questionPageAnswers() {
-    return this.questionPages.map((page) => ({
+    return this._questionPages.map((page) => ({
       page,
       answer: this._data[page.questionKey].answer
     }))
@@ -71,7 +71,7 @@ export class SectionModel {
   /**
    * returns {QuestionPage[]}
    */
-  get questionPages() {
+  get _questionPages() {
     return this._pages.filter((p) => p instanceof QuestionPage)
   }
 
@@ -84,7 +84,7 @@ export class SectionModel {
     }
 
     if (page instanceof ExitPage) {
-      const questionPages = this.questionPages
+      const questionPages = this._questionPages
       return {
         isValid: false,
         firstInvalidPage: questionPages[questionPages.length - 1]

--- a/src/server/common/model/section/section-model/section-model.js
+++ b/src/server/common/model/section/section-model/section-model.js
@@ -62,17 +62,12 @@ export class SectionModel {
    * @returns {PageAnswer[]}
    */
   get questionPageAnswers() {
-    return this._questionPages.map((page) => ({
-      page,
-      answer: this._data[page.questionKey].answer
-    }))
-  }
-
-  /**
-   * returns {QuestionPage[]}
-   */
-  get _questionPages() {
-    return this._pages.filter((p) => p instanceof QuestionPage)
+    return this._pages
+      .filter((p) => p instanceof QuestionPage)
+      .map((page) => ({
+        page,
+        answer: this._data[page.questionKey].answer
+      }))
   }
 
   /** @returns {SectionValidation} */
@@ -84,10 +79,11 @@ export class SectionModel {
     }
 
     if (page instanceof ExitPage) {
-      const questionPages = this._questionPages
+      const questionPageAnswers = this.questionPageAnswers
       return {
         isValid: false,
-        firstInvalidPage: questionPages[questionPages.length - 1]
+        firstInvalidPage:
+          questionPageAnswers[questionPageAnswers.length - 1].page
       }
     }
 

--- a/src/server/common/model/section/section-model/section-model.js
+++ b/src/server/common/model/section/section-model/section-model.js
@@ -59,6 +59,16 @@ export class SectionModel {
   }
 
   /**
+   * @returns {PageAnswer[]}
+   */
+  get questionPageAnswers() {
+    return this.questionPages.map((page) => ({
+      page,
+      answer: this._data[page.questionKey].answer
+    }))
+  }
+
+  /**
    * returns {QuestionPage[]}
    */
   get questionPages() {

--- a/src/server/common/model/section/section-model/section-model.test.js
+++ b/src/server/common/model/section/section-model/section-model.test.js
@@ -5,6 +5,8 @@ import { OriginSection } from '../origin/origin.js'
 import { CphNumberAnswer } from '../../answer/cph-number/cph-number.js'
 import { OriginExitPage } from '~/src/server/exit-page/index.js'
 import { OriginSummaryPage } from '~/src/server/origin/summary/index.js'
+import { OriginAddressPage } from '~/src/server/origin/address/index.js'
+import { AddressAnswer } from '../../answer/address/address.js'
 
 /** @import {OnOffFarmData} from '~/src/server/common/model/answer/on-off-farm/on-off-farm.js' */
 
@@ -58,6 +60,23 @@ describe('SectionModel.questionPages', () => {
     expect(origin[pages.at(1)?.questionKey ?? 'invalid']).toBeInstanceOf(
       CphNumberAnswer
     )
+  })
+})
+
+describe('SectionModel.questionPageAnswers', () => {
+  it('should return all of the pages with answers pre-populated', () => {
+    const origin = OriginSection.fromState(validState)
+    const pageAnswers = origin.questionPageAnswers
+
+    expect(pageAnswers).toHaveLength(3)
+    expect(pageAnswers.at(0)?.page).toBeInstanceOf(OnOffFarmPage)
+    expect(pageAnswers.at(0)?.answer).toBeInstanceOf(OnOffFarmAnswer)
+
+    expect(pageAnswers.at(1)?.page).toBeInstanceOf(CphNumberPage)
+    expect(pageAnswers.at(1)?.answer).toBeInstanceOf(CphNumberAnswer)
+
+    expect(pageAnswers.at(2)?.page).toBeInstanceOf(OriginAddressPage)
+    expect(pageAnswers.at(2)?.answer).toBeInstanceOf(AddressAnswer)
   })
 })
 

--- a/src/server/common/model/section/section-model/section-model.test.js
+++ b/src/server/common/model/section/section-model/section-model.test.js
@@ -34,35 +34,6 @@ const exitState = {
   address: validAddress // this is unreachable in the journey, because we will have exited already
 }
 
-describe('SectionModel.questionPages', () => {
-  it('should short-circuit on an exit page', () => {
-    const origin = OriginSection.fromState(exitState)
-    const pages = origin._questionPages
-
-    expect(pages).toHaveLength(1)
-    expect(pages.at(0)).toBeInstanceOf(OnOffFarmPage)
-    expect(origin[pages.at(0)?.questionKey ?? 'invalid']).toBeInstanceOf(
-      OnOffFarmAnswer
-    )
-  })
-
-  it('should short-circuit on a page with an invalid answer', () => {
-    const origin = OriginSection.fromState(invalidState)
-    const pages = origin._questionPages
-
-    expect(pages).toHaveLength(2)
-    expect(pages.at(0)).toBeInstanceOf(OnOffFarmPage)
-    expect(origin[pages.at(0)?.questionKey ?? 'invalid']).toBeInstanceOf(
-      OnOffFarmAnswer
-    )
-
-    expect(pages.at(1)).toBeInstanceOf(CphNumberPage)
-    expect(origin[pages.at(1)?.questionKey ?? 'invalid']).toBeInstanceOf(
-      CphNumberAnswer
-    )
-  })
-})
-
 describe('SectionModel.questionPageAnswers', () => {
   it('should return all of the pages with answers pre-populated', () => {
     const origin = OriginSection.fromState(validState)
@@ -77,6 +48,27 @@ describe('SectionModel.questionPageAnswers', () => {
 
     expect(pageAnswers.at(2)?.page).toBeInstanceOf(OriginAddressPage)
     expect(pageAnswers.at(2)?.answer).toBeInstanceOf(AddressAnswer)
+  })
+
+  it('should short-circuit on an exit page', () => {
+    const origin = OriginSection.fromState(exitState)
+    const pageAnswers = origin.questionPageAnswers
+
+    expect(pageAnswers).toHaveLength(1)
+    expect(pageAnswers.at(0)?.page).toBeInstanceOf(OnOffFarmPage)
+    expect(pageAnswers.at(0)?.answer).toBeInstanceOf(OnOffFarmAnswer)
+  })
+
+  it('should short-circuit on a page with an invalid answer', () => {
+    const origin = OriginSection.fromState(invalidState)
+    const pageAnswers = origin.questionPageAnswers
+
+    expect(pageAnswers).toHaveLength(2)
+    expect(pageAnswers.at(0)?.page).toBeInstanceOf(OnOffFarmPage)
+    expect(pageAnswers.at(0)?.answer).toBeInstanceOf(OnOffFarmAnswer)
+
+    expect(pageAnswers.at(1)?.page).toBeInstanceOf(CphNumberPage)
+    expect(pageAnswers.at(1)?.answer).toBeInstanceOf(CphNumberAnswer)
   })
 })
 

--- a/src/server/common/model/section/section-model/section-model.test.js
+++ b/src/server/common/model/section/section-model/section-model.test.js
@@ -37,7 +37,7 @@ const exitState = {
 describe('SectionModel.questionPages', () => {
   it('should short-circuit on an exit page', () => {
     const origin = OriginSection.fromState(exitState)
-    const pages = origin.questionPages
+    const pages = origin._questionPages
 
     expect(pages).toHaveLength(1)
     expect(pages.at(0)).toBeInstanceOf(OnOffFarmPage)
@@ -48,7 +48,7 @@ describe('SectionModel.questionPages', () => {
 
   it('should short-circuit on a page with an invalid answer', () => {
     const origin = OriginSection.fromState(invalidState)
-    const pages = origin.questionPages
+    const pages = origin._questionPages
 
     expect(pages).toHaveLength(2)
     expect(pages.at(0)).toBeInstanceOf(OnOffFarmPage)


### PR DESCRIPTION
I want to take this step for a few reasons

## Simplifying Section definition

Currently, each controller is expected to have a getter for every answer - so that it can be rendered in a check-answers summary. 
What those check-answers pages really need are the pages & answers of the relevant summaries. 

Now they only need to fetch questionPageAnswers for all the data needed to render a summary correctly.

## Opens the door to further simplifications

Each SectionModel currently defines the list of questions that are relevant in 'fromState'.  It also dynamically walks the graph of questions (starting from the firstPage).

If we depend only on questionPageAnswers to render check-summary pages, it makes the step of dynamically generating the pages & answers relevant to section from the first page much simpler.

At that stage, a section definition becomes: 

```javascript
export class OriginSection extends SectionModel {
  firstPage = onOffFarmPage
}
```

with no need to update the section model every time we add a new question to the section.  If it's available via nextPage iteration from the section's firstPage, it's in the section automatically - in both the validity checks & in the check-answers summaries.