### PR TITLE
BAU: run sonarcloud before publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,6 +32,12 @@ jobs:
           npm run build
           npm test
 
+      - name: SonarCloud Scan
+        uses: SonarSource/sonarcloud-github-action@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+
       - name: Start docker compose
         run: |
             docker compose up --wait-timeout 300 -d --quiet-pull
@@ -42,7 +48,7 @@ jobs:
         env:
           BROWSERSTACK_USER: ${{ secrets.BROWSERSTACK_USER }}
           BROWSERSTACK_KEY: ${{ secrets.BROWSERSTACK_KEY }}
-  
+
       - name: cleanup
         if: always()
         run: docker compose down
@@ -52,8 +58,3 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: SonarCloud Scan
-        uses: SonarSource/sonarcloud-github-action@master
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
Our checks are meant to ensure the quality of the releasable artifact before they can be promoted to any CDP environment - so it makes sense that we put the sonarcloud checks before we push the release to ECR.

It's also not worth running the very expensive browserstack tests to only then fail on a sonarcloud check & have to go through that process again.