### PR TITLE
BAU: remove app-main wrapper to match prototype

### DIFF
--- a/src/client/stylesheets/core/_all.scss
+++ b/src/client/stylesheets/core/_all.scss
@@ -1,2 +1,1 @@
 @import "header";
-@import "main";

--- a/src/client/stylesheets/core/_main.scss
+++ b/src/client/stylesheets/core/_main.scss
@@ -1,5 +1,0 @@
-.app-main-wrapper {
-  display: block;
-  padding-top: govuk-spacing(4);
-  padding-bottom: govuk-spacing(3);
-}

--- a/src/server/common/templates/layouts/page.njk
+++ b/src/server/common/templates/layouts/page.njk
@@ -3,7 +3,6 @@
 {% from "heading/macro.njk" import appHeading %}
 {% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
-{% set mainClasses = "app-main-wrapper" %}
 
 {% block head %}
   <link


### PR DESCRIPTION
This additional class causes a difference in the vertical padding between the main content of the prototype & this implementation.

This makes direct comparison between the prototype & implementation more difficult than necessary.