### PR TITLE
BAU: add build badges to enhance visibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 [![Security Rating](https://sonarcloud.io/api/project_badges/measure?project=DEFRA_apha-apps-perms-move-animal-ui&metric=security_rating)](https://sonarcloud.io/summary/new_code?id=DEFRA_apha-apps-perms-move-animal-ui)
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=DEFRA_apha-apps-perms-move-animal-ui&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=DEFRA_apha-apps-perms-move-animal-ui)
 [![Coverage](https://sonarcloud.io/api/project_badges/measure?project=DEFRA_apha-apps-perms-move-animal-ui&metric=coverage)](https://sonarcloud.io/summary/new_code?id=DEFRA_apha-apps-perms-move-animal-ui)
+![Publish Workflow Status](https://github.com/DEFRA/apha-apps-perms-move-animal-ui/actions/workflows/publish.yml/badge.svg)
+![Run Tests Browserstack Status](https://github.com/DEFRA/apha-apps-perms-move-animal-ui/actions/workflows/run-tests-browserstack.yaml/badge.svg)
 
 Frontend to the 'Move animals under disease control restriction' service.
 


### PR DESCRIPTION
The default action page shows a list of breakages - but it doesn't make it clear (without some extra eyeball work) which jobs have returned to a good state.

As a result, it's quite easy to miss - in particular - the extended browserstack test failures.

This makes the things that we want to be green all the time obvious - the publish & the extended tests, which both run off the main branch.