### PR TITLE
BAU: move iOS tests into their own run

### DIFF
--- a/.github/workflows/run-tests-browserstack-desktop.yaml
+++ b/.github/workflows/run-tests-browserstack-desktop.yaml
@@ -1,9 +1,9 @@
-name: Browserstack extended tests
+name: Browserstack extended tests (desktop)
 
 on:
   workflow_run:
     workflows: [ "Publish" ]
-    types: 
+    types:
       - completed
 
 env:
@@ -11,7 +11,7 @@ env:
   AWS_ACCOUNT_ID: "094954420758"
 
 concurrency:
-  group: browserstack-extended-tests
+  group: browserstack-extended-tests-desktop
 
 jobs:
   build:
@@ -28,7 +28,7 @@ jobs:
       - name: Browserstack tests
         run: |
             npm ci
-            npm run user-journey-test:bs-extended
+            npm run user-journey-test:bs-extended-desktop
         env:
           BROWSERSTACK_USER: ${{ secrets.BROWSERSTACK_USER }}
           BROWSERSTACK_KEY: ${{ secrets.BROWSERSTACK_KEY }}

--- a/.github/workflows/run-tests-browserstack-mobile.yaml
+++ b/.github/workflows/run-tests-browserstack-mobile.yaml
@@ -1,0 +1,38 @@
+name: Browserstack extended tests (mobile)
+
+on:
+  workflow_run:
+    workflows: [ "Publish" ]
+    types:
+      - completed
+
+env:
+  AWS_REGION: eu-west-2
+  AWS_ACCOUNT_ID: "094954420758"
+
+concurrency:
+  group: browserstack-extended-tests-mobile
+
+jobs:
+  build:
+    name: CDP-build-workflow
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Start docker compose
+        run: |
+            docker compose up --wait-timeout 300 -d --quiet-pull
+
+      - name: Browserstack tests
+        run: |
+            npm ci
+            npm run user-journey-test:bs-extended-mobile
+        env:
+          BROWSERSTACK_USER: ${{ secrets.BROWSERSTACK_USER }}
+          BROWSERSTACK_KEY: ${{ secrets.BROWSERSTACK_KEY }}
+
+      - name: cleanup
+        if: always()
+        run: docker compose down

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=DEFRA_apha-apps-perms-move-animal-ui&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=DEFRA_apha-apps-perms-move-animal-ui)
 [![Coverage](https://sonarcloud.io/api/project_badges/measure?project=DEFRA_apha-apps-perms-move-animal-ui&metric=coverage)](https://sonarcloud.io/summary/new_code?id=DEFRA_apha-apps-perms-move-animal-ui)
 ![Publish Workflow Status](https://github.com/DEFRA/apha-apps-perms-move-animal-ui/actions/workflows/publish.yml/badge.svg)
-![Run Tests Browserstack Status](https://github.com/DEFRA/apha-apps-perms-move-animal-ui/actions/workflows/run-tests-browserstack.yaml/badge.svg)
+![Run Tests Browserstack (desktop) Status](https://github.com/DEFRA/apha-apps-perms-move-animal-ui/actions/workflows/run-tests-browserstack-desktop.yaml/badge.svg)
+![Run Tests Browserstack (mobile) Status](https://github.com/DEFRA/apha-apps-perms-move-animal-ui/actions/workflows/run-tests-browserstack-mobile.yaml/badge.svg)
 
 Frontend to the 'Move animals under disease control restriction' service.
 

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "user-journey-test:js": "wdio run ./user-journey-tests/wdioJS.conf.js",
     "user-journey-test:nojs": "wdio run ./user-journey-tests/wdioNoJS.conf.js",
     "user-journey-test:bs": "wdio run ./user-journey-tests/wdio.browserstack.conf.js",
-    "user-journey-test:bs-extended": "wdio run ./user-journey-tests/wdio.browserstack.extended.conf.js"
+    "user-journey-test:bs-extended-desktop": "wdio run ./user-journey-tests/wdio.browserstack.extended-desktop.conf.js",
+    "user-journey-test:bs-extended-mobile": "wdio run ./user-journey-tests/wdio.browserstack.extended-mobile.conf.js"
   },
   "author": "Defra DDTS",
   "license": "OGL-UK-3.0",

--- a/user-journey-tests/wdio.browserstack.extended-desktop.conf.js
+++ b/user-journey-tests/wdio.browserstack.extended-desktop.conf.js
@@ -1,0 +1,45 @@
+import { config as browserstackBaseConfig } from './wdio.browserstack.conf.js'
+
+//  These capabilities should run as an extended test after publishing
+export const config = {
+  ...browserstackBaseConfig,
+  maxInstances: 4,
+  capabilities: [
+    {
+      browserName: 'Chrome',
+      'bstack:options': {
+        browserVersion: 'latest',
+        os: 'Windows',
+        osVersion: '10',
+        sessionName: 'windows-chrome'
+      }
+    },
+    {
+      browserName: 'Firefox',
+      'bstack:options': {
+        browserVersion: 'latest',
+        os: 'Windows',
+        osVersion: '10',
+        sessionName: 'windows-firefox'
+      }
+    },
+    {
+      browserName: 'Chrome',
+      'bstack:options': {
+        browserVersion: 'latest',
+        os: 'OS X',
+        osVersion: 'Monterey',
+        sessionName: 'osx-chrome'
+      }
+    },
+    {
+      browserName: 'Firefox',
+      'bstack:options': {
+        browserVersion: 'latest',
+        os: 'OS X',
+        osVersion: 'Monterey',
+        sessionName: 'osx-firefox'
+      }
+    }
+  ]
+}

--- a/user-journey-tests/wdio.browserstack.extended-mobile.js
+++ b/user-journey-tests/wdio.browserstack.extended-mobile.js
@@ -3,44 +3,8 @@ import { config as browserstackBaseConfig } from './wdio.browserstack.conf.js'
 //  These capabilities should run as an extended test after publishing
 export const config = {
   ...browserstackBaseConfig,
-  maxInstances: 7,
+  maxInstances: 3,
   capabilities: [
-    {
-      browserName: 'Chrome',
-      'bstack:options': {
-        browserVersion: 'latest',
-        os: 'Windows',
-        osVersion: '10',
-        sessionName: 'windows-chrome'
-      }
-    },
-    {
-      browserName: 'Firefox',
-      'bstack:options': {
-        browserVersion: 'latest',
-        os: 'Windows',
-        osVersion: '10',
-        sessionName: 'windows-firefox'
-      }
-    },
-    {
-      browserName: 'Chrome',
-      'bstack:options': {
-        browserVersion: 'latest',
-        os: 'OS X',
-        osVersion: 'Monterey',
-        sessionName: 'osx-chrome'
-      }
-    },
-    {
-      browserName: 'Firefox',
-      'bstack:options': {
-        browserVersion: 'latest',
-        os: 'OS X',
-        osVersion: 'Monterey',
-        sessionName: 'osx-firefox'
-      }
-    },
     {
       browserName: 'Safari',
       'bstack:options': {


### PR DESCRIPTION
We're seeing multiple intermittent in our browserstack extended tests,
but they only appear to be within iOS.

This creates a 'noisy alert' problem - if we expect our extended tests
to fail frequently, we will start taking test failure less seriously
(since it's likely just the known iOS issue).  Which, in turn, makes it
likely that we'll respond slower to regressions on the stable test run
targets - the desktop browsers.

Separating out the unstable mobile tests from the desktop tests gives us
a functioning test signal again for the desktop arena.