### PR TITLE
BAU: revert ubuntu runner for check prs to 22.04

### DIFF
--- a/.github/workflows/check-pull-request.yml
+++ b/.github/workflows/check-pull-request.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   pr-validator:
     name: Run Pull Request Checks
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
Github actions have upgraded the test runner for ubuntu-latest from 22.04 to 24.04, which has caused a ChromeDriver not to be able to start chrome & create a session:

> ERROR webdriver: session not created: session not created: Chrome failed to start: exited normally
> [0-2]   (session not created: DevToolsActivePort file doesn't exist)

A longer-term fix involves not depending on the in-built, convenience browser instance from the github runner.  This could be browserstack, or it could be running a selenium docker instance (the approach the CDP template is now taking).