### PR TITLE
BAU: remove memory-leaking logger we don't yet use

### DIFF
--- a/src/server/common/controller/generic-page-controller/index.js
+++ b/src/server/common/controller/generic-page-controller/index.js
@@ -4,7 +4,6 @@ import {
   StorageResolution
 } from 'aws-embedded-metrics'
 import { config } from '~/src/config/config.js'
-import { createLogger } from '../../helpers/logging/logger.js'
 import { NotImplementedError } from '../../helpers/not-implemented-error.js'
 
 /**
@@ -29,7 +28,6 @@ import { NotImplementedError } from '../../helpers/not-implemented-error.js'
 
 export default class GenericPageController {
   metrics = createMetricsLogger()
-  logger = createLogger()
 
   /**
    * @param {Page} page

--- a/src/server/common/controller/generic-page-controller/index.test.js
+++ b/src/server/common/controller/generic-page-controller/index.test.js
@@ -49,9 +49,6 @@ describe('#GenericPageController', () => {
       throw new Error('test error')
     })
 
-    jest.spyOn(controller.logger, 'error').mockImplementation(() => {
-      throw new Error('test error')
-    })
     expect(() => controller.getHandler()).toThrow()
   })
 
@@ -60,9 +57,6 @@ describe('#GenericPageController', () => {
       throw new Error('test error')
     })
 
-    jest.spyOn(controller.logger, 'error').mockImplementation(() => {
-      throw new Error('test error')
-    })
     expect(() => controller.postHandler()).toThrow()
   })
 


### PR DESCRIPTION
Running unit tests, it was warning of an event emitter leak - and slowing down substantially over time.

Using `node --trace-warnings node_modules/.bin/jest -i`, it identified the createLogger() function call within each of the subclasses.

This is because properties are initialised on class instantiation, so every time we were creating an instance for our classes under test, we were creating a new logger.

I'm removing this for now - to prevent any issues in development - since we're not actively using this logger.

When we need to re-introduce it, we can find a more pino-friendly way to do it.