### PR TITLE
BAU: remove duplicate metrics

### DIFF
--- a/src/server/common/controller/generic-page-controller/index.js
+++ b/src/server/common/controller/generic-page-controller/index.js
@@ -9,16 +9,6 @@ import { createLogger } from '../../helpers/logging/logger.js'
  * export @interface PageController {
  *  handleGet: (req: Request, h: ResponseToolkit) => ResponseObject
  * }
- *
- * export @typedef {{
- *   request ?: boolean;
- *   response ?: boolean;
- * }} Metrics
- *
- * export @typedef {{
- *   get ?: Metrics;
- *   post ?: Metrics;
- * }} MetricReports
  */
 
 const logger = createLogger()
@@ -35,21 +25,14 @@ export default class GenericPageController {
   }
 
   getHandler(req, h) {
-    this.sendLog('get', 'request')
-    const result = this.handleGet(req, h)
-    this.sendLog('get', 'response')
-    return result
+    return this.handleGet(req, h)
   }
 
   postHandler(req, h) {
-    this.sendLog('post', 'request')
-    const result = this.handlePost(req, h)
-    this.sendLog('post', 'response')
-    return result
+    return this.handlePost(req, h)
   }
 
   /**
-   *
    * @param {import('../../model/answer/validation.js').AnswerErrors} errors
    */
   recordErrors(errors) {
@@ -59,20 +42,6 @@ export default class GenericPageController {
   }
 
   /**
-   *
-   * @param {string} method
-   * @param {string} event
-   */
-  sendLog(method, event) {
-    const sendMetric = this.page.reportMetrics?.[method]?.[event]
-
-    if (sendMetric) {
-      this.logger.info(`${method}::${event}-${this.page.urlPath}`)
-    }
-  }
-
-  /**
-   *
    * @param {string} field
    * @param {string} error
    */

--- a/src/server/common/controller/generic-page-controller/index.test.js
+++ b/src/server/common/controller/generic-page-controller/index.test.js
@@ -57,30 +57,6 @@ describe('#GenericPageController', () => {
     expect(() => controller.postHandler()).toThrow()
   })
 
-  it('should send metric on getHandler', () => {
-    jest.spyOn(controller, 'handleGet').mockImplementation(() => {
-      return 'get success'
-    })
-    const logger = jest.spyOn(controller.logger, 'info')
-
-    const metricSpy = jest.spyOn(controller, 'sendLog')
-    controller.getHandler()
-    expect(controller.sendLog).toHaveBeenCalledWith('get', 'response')
-    expect(metricSpy).toHaveBeenCalledTimes(2)
-    expect(logger).toHaveBeenCalledTimes(1)
-  })
-
-  it('should send metric on postHandler', () => {
-    jest.spyOn(controller, 'handlePost').mockImplementation(() => {
-      return 'get success'
-    })
-
-    const metricSpy = jest.spyOn(controller, 'sendLog')
-    controller.postHandler()
-    expect(controller.sendLog).toHaveBeenCalledWith('post', 'response')
-    expect(metricSpy).toHaveBeenCalledTimes(2)
-  })
-
   afterEach(() => {
     jest.clearAllMocks()
   })

--- a/src/server/common/model/page/page-model.js
+++ b/src/server/common/model/page/page-model.js
@@ -1,20 +1,7 @@
 import { NotImplementedError } from '../../helpers/not-implemented-error.js'
 /** @import { AnswerModel } from '../answer/answer-model.js' */
-/** @import { MetricReports, Metrics } from '../../controller/generic-page-controller/index.js' */
 
 export class Page {
-  /** @type {MetricReports} */
-  reportMetrics = {
-    get: {
-      request: false,
-      response: false
-    },
-    post: {
-      request: false,
-      response: false
-    }
-  }
-
   /** @type {string} */
   urlPath
 


### PR DESCRIPTION
In the CDP platform, we have an nginx cluster in front of the services that gives us logs with messages that look like:

`[response] get /origin/type-of-origin 200 (8ms)`

There are also common fields parsed out - e.g referrer, path, etc

This is already being rendered into a count graph in grafana (based on a lucene query against those logs).  We could make version of the graph that splits that by method and/or url too (with CDP's help), since both are parsed as separate fields from the nginx log.

We don't need to additionally log this manually from the service itself.