### PR TITLE
BAU: run extended browserstack tests at night

### DIFF
--- a/.github/workflows/run-tests-browserstack-desktop.yaml
+++ b/.github/workflows/run-tests-browserstack-desktop.yaml
@@ -1,10 +1,8 @@
 name: Browserstack extended tests (desktop)
 
 on:
-  workflow_run:
-    workflows: ['Publish']
-    types:
-      - completed
+  schedule:
+    - cron: "0 0 * * *" # Runs at midnight
 
 env:
   AWS_REGION: eu-west-2

--- a/.github/workflows/run-tests-browserstack-mobile.yaml
+++ b/.github/workflows/run-tests-browserstack-mobile.yaml
@@ -2,7 +2,7 @@ name: Browserstack extended tests (mobile)
 
 on:
   schedule:
-    - cron: "0 */12 * * *" # Runs every 12 hours
+    - cron: "0 1 * * *" # Runs at 1am
 
 env:
   AWS_REGION: eu-west-2

--- a/user-journey-tests/wdio.browserstack.conf.js
+++ b/user-journey-tests/wdio.browserstack.conf.js
@@ -7,7 +7,7 @@ export const config = merge(wdioConf, {
   exclude: ['./specs/noJavascript/**/*.spec.js'],
   user: process.env.BROWSERSTACK_USER,
   key: process.env.BROWSERSTACK_KEY,
-  maxInstances: 7,
+  maxInstances: 5,
   capabilities: [
     {
       browserName: 'Edge',


### PR DESCRIPTION
Because of resource limits placed on browserstack, we've experienced a great number of failed test runs that relate to exhausted resources & intermittent browserstack issues.

This also causes failures in our own *publish* job, which is the critical path to production.  The issue is worst when we're at our most productive - merging new code into main.

These tests have rarely uncovered anything that isn't exposed in the user-journey-test run against Chrome, nor against the pair we've introduced for the publish pipeline (so that we're testing on at least a range of desktop browsers before we have a viable build).

As a result, I'm suggesting we push these to late-night cron jobs.  We can see the result in the build radiator style badges on the README in github, and correct if necessary.