### PR TITLE
BAU: lift viewModel into a generic AnswerModel fn

### DIFF
--- a/src/server/common/controller/question-page-controller/question-page-controller.js
+++ b/src/server/common/controller/question-page-controller/question-page-controller.js
@@ -52,6 +52,7 @@ export class QuestionPageController extends GenericPageController {
       heading: this.page.heading,
       value: answer.value,
       answer,
+      viewModelOptions: { validate: false },
       ...this.page.viewProps(req)
     })
   }
@@ -76,6 +77,7 @@ export class QuestionPageController extends GenericPageController {
         heading: this.page.heading,
         value: answer.value,
         answer,
+        viewModelOptions: { validate: true },
         errors,
         errorMessages: Answer.errorMessages(errors),
         ...this.page.viewProps(req)

--- a/src/server/common/controller/question-page-controller/question-page-controller.test.js
+++ b/src/server/common/controller/question-page-controller/question-page-controller.test.js
@@ -465,7 +465,8 @@ describe('QuestionPageController', () => {
           heading: question,
           nextPage: 'redirect_uri',
           pageTitle: question,
-          value: undefined
+          value: undefined,
+          viewModelOptions: { validate: false }
         })
       )
 
@@ -491,6 +492,7 @@ describe('QuestionPageController', () => {
             { href: `#${questionKey}`, text: 'There is a problem' }
           ],
           errors: { questionKey: { text: 'There is a problem' } },
+          viewModelOptions: { validate: true },
           heading: question,
           nextPage: 'test_next_page',
           pageTitle: `Error: ${question}`,

--- a/src/server/common/model/answer/answer-model.js
+++ b/src/server/common/model/answer/answer-model.js
@@ -69,6 +69,13 @@ export class AnswerModel {
   }
 
   /**
+   * @params {AnswerViewModelOptions} options
+   */
+  viewModel(options) {
+    throw new NotImplementedError()
+  }
+
+  /**
    * @param {unknown} _data
    * @returns {unknown}
    */
@@ -90,4 +97,8 @@ export class AnswerModel {
 
 /**
  * @typedef {{[key:string]: string | undefined}} RawPayload
+ */
+
+/**
+ * @typedef {{ validate: boolean }} AnswerViewModelOptions
  */

--- a/src/server/common/model/answer/answer-model.js
+++ b/src/server/common/model/answer/answer-model.js
@@ -69,9 +69,9 @@ export class AnswerModel {
   }
 
   /**
-   * @param {AnswerViewModelOptions} options
+   * @param {AnswerViewModelOptions} _options
    */
-  viewModel(options) {
+  viewModel(_options) {
     throw new NotImplementedError()
   }
 

--- a/src/server/common/model/answer/answer-model.js
+++ b/src/server/common/model/answer/answer-model.js
@@ -69,7 +69,7 @@ export class AnswerModel {
   }
 
   /**
-   * @params {AnswerViewModelOptions} options
+   * @param {AnswerViewModelOptions} options
    */
   viewModel(options) {
     throw new NotImplementedError()

--- a/src/server/common/model/answer/answer-model.test.js
+++ b/src/server/common/model/answer/answer-model.test.js
@@ -28,6 +28,12 @@ describe('AnswerModel', () => {
     expect(() => AnswerModel.fromState({})).toThrow(notImplementedError)
   })
 
+  it('should throw NotImplementedError when viewModel is called', () => {
+    expect(() => answer.viewModel({ validate: true })).toThrow(
+      notImplementedError
+    )
+  })
+
   it('should seal the object to prevent property additions or deletions', () => {
     class AnswerModelBasic extends AnswerModel {
       _extractFields(data) {

--- a/src/server/common/model/answer/radio-button/radio-button.js
+++ b/src/server/common/model/answer/radio-button/radio-button.js
@@ -3,6 +3,8 @@ import { AnswerModel } from '../answer-model.js'
 import { validateAnswerAgainstSchema } from '../validation.js'
 import { NotImplementedError } from '../../../helpers/not-implemented-error.js'
 
+/** @import {AnswerViewModelOptions} from '../answer-model.js' */
+
 /* eslint-disable jsdoc/require-returns-check */
 
 /**
@@ -93,7 +95,10 @@ export class RadioButtonAnswer extends AnswerModel {
     })
   }
 
-  get viewModel() {
+  /**
+   * @param {AnswerViewModelOptions} options
+   */
+  viewModel({ validate }) {
     const items = Object.entries(this.config.options).map(([key, value]) => ({
       id: key,
       value: key,
@@ -103,12 +108,18 @@ export class RadioButtonAnswer extends AnswerModel {
       }
     }))
     items[0].id = this.config.payloadKey
-    return {
+
+    const model = {
       name: this.config.payloadKey,
       id: this.config.payloadKey,
       fieldset: {},
       value: this.value,
       items
     }
+
+    if (validate) {
+      model.errorMessage = this.validate().errors[this.config.payloadKey]
+    }
+    return model
   }
 }

--- a/src/server/common/model/answer/radio-button/radio-button.njk
+++ b/src/server/common/model/answer/radio-button/radio-button.njk
@@ -1,2 +1,2 @@
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
-{{ govukRadios(assign({}, answer.viewModel, { errorMessage: errors[answer.config.payloadKey]})) }}
+{{ govukRadios(answer.viewModel(viewModelOptions)) }}

--- a/src/server/common/model/answer/radio-button/radio-button.test.js
+++ b/src/server/common/model/answer/radio-button/radio-button.test.js
@@ -166,13 +166,12 @@ describe('RadioButton', () => {
         }
       ]
     }
+
     it('should return everything (except errors) to render in the template', () => {
       expect(answer.viewModel({ validate: false })).toEqual(defaultViewModel)
     })
 
     it('should return everything (including errors) to render in the template', () => {
-      console.log(answer.viewModel({ validate: true }))
-      console.log(answer.validate().errors)
       expect(answer.viewModel({ validate: true })).toEqual({
         ...defaultViewModel,
         errorMessage: { text: 'Select an option' }

--- a/src/server/common/model/answer/radio-button/radio-button.test.js
+++ b/src/server/common/model/answer/radio-button/radio-button.test.js
@@ -141,31 +141,41 @@ describe('RadioButton', () => {
   })
 
   describe('#RadioButton.viewModel', () => {
-    it('should return everything (except errors) to render in the template', () => {
-      const answer = new RadioButtonTest({ test_radio: 'value_1' })
-      expect(answer.viewModel).toEqual({
-        name: 'test_radio',
-        id: 'test_radio',
-        fieldset: {},
-        value: answer.value,
-        items: [
-          {
-            id: 'test_radio',
-            value: 'value_1',
-            text: 'test_label_1',
-            hint: {
-              text: undefined
-            }
-          },
-          {
-            id: 'value_2',
-            value: 'value_2',
-            text: 'test_label_2',
-            hint: {
-              text: 'test_hint_2'
-            }
+    const answer = new RadioButtonTest({ test_radio: 'invalid_answer' })
+    const defaultViewModel = {
+      name: 'test_radio',
+      id: 'test_radio',
+      fieldset: {},
+      value: answer.value,
+      items: [
+        {
+          id: 'test_radio',
+          value: 'value_1',
+          text: 'test_label_1',
+          hint: {
+            text: undefined
           }
-        ]
+        },
+        {
+          id: 'value_2',
+          value: 'value_2',
+          text: 'test_label_2',
+          hint: {
+            text: 'test_hint_2'
+          }
+        }
+      ]
+    }
+    it('should return everything (except errors) to render in the template', () => {
+      expect(answer.viewModel({ validate: false })).toEqual(defaultViewModel)
+    })
+
+    it('should return everything (including errors) to render in the template', () => {
+      console.log(answer.viewModel({ validate: true }))
+      console.log(answer.validate().errors)
+      expect(answer.viewModel({ validate: true })).toEqual({
+        ...defaultViewModel,
+        errorMessage: { text: 'Select an option' }
       })
     })
   })


### PR DESCRIPTION
Ultimately, I'd like to see us:
- define a view for each Answerodel
- have an answer know how to populate that view (based on its configuration)

As part of the transition, I'm:
- Adding a viewModel to the base AnswerModel class
- passing in the validation options (so the AnswerModel can be responsible for adding the errors itself).

Once we have moved all models over to this way of doing things, we can:
- removing passing the value & errorMessage in via the QuestionPageController
- add the view template to the AnswerModel class itself
- update layouts/questions.njk to look up the view & render it from the AnswerModel class

Note that the viewModel for a class can return anything that satisfies its own template.  There's no one-size-fits-all expectation for viewModels across types such as radio buttons, addresses, names, etc.

Also note that most Answers won't need their own viewModels and templates - if they're merely configured version of more generic types. See RadioButton for an example of this.