### PR TITLE
DSFAAP-765: add a label to final answers checkbox

### DIFF
--- a/src/server/check-answers/__snapshots__/index.test.js.snap
+++ b/src/server/check-answers/__snapshots__/index.test.js.snap
@@ -122,13 +122,12 @@ exports[`#CheckAnswers Should provide expected response 1`] = `
         <input type="hidden" name="crumb" value="csrf-value">
         <input type="hidden" name="nextPage" value="">
   <h2 class="govuk-heading-m">Your declaration</h2>
-  <p>
-    Before you submit your application, you must select one of the declaration
-    check boxes.
-  </p>
   <!-- form URL below turns off errors on the next page  -->
   <div class="govuk-form-group">
   <fieldset class="govuk-fieldset">
+    <legend class="govuk-fieldset__legend">
+      Before you submit your application, you must select one of the declaration check boxes.
+    </legend>
     <div class="govuk-checkboxes" data-module="govuk-checkboxes">
       <div class="govuk-checkboxes__item">
         <input class="govuk-checkboxes__input" id="confirmation" name="confirmation" type="checkbox" value="confirm" data-testid="confirm-statements-checkbox">

--- a/src/server/check-answers/index.njk
+++ b/src/server/check-answers/index.njk
@@ -26,10 +26,6 @@
 {% endblock %}
 {% block questions %}
   <h2 class="govuk-heading-m">Your declaration</h2>
-  <p>
-    Before you submit your application, you must select one of the declaration
-    check boxes.
-  </p>
   <!-- form URL below turns off errors on the next page  -->
   {{
     govukCheckboxes
@@ -39,9 +35,8 @@
       errorMessage: errors.confirmation,
       fieldset: {
         legend:{
-          text: "",
-          isPageHeading: false,
-          classes: "govuk-fieldset__legend--m"
+          text: "Before you submit your application, you must select one of the declaration check boxes.",
+          isPageHeading: false
         }
       },
       items: [{


### PR DESCRIPTION
This text seems (to me) to be the closest to an appropriate label we have for the checkboxes.  I think it fits with what a user would want to hear (and would hear)  the guidance given here: https://accessibility.blog.gov.uk/2016/07/22/using-the-fieldset-and-legend-elements/

It does change the whitespace subtly.  Our version looks like:
![image](https://github.com/user-attachments/assets/dc0cc03f-b186-4ce7-8085-55ae8bddee97)

Where's the [prototype (v2_0_0)](https://applicationsandpermissions-dev-ffeda85e15b1.herokuapp.com/v2_0_0/create-application/submit/check-answers) looks like:
![image](https://github.com/user-attachments/assets/0b24b7c4-9bc3-456f-be6e-de768bcda554)

Looking at the prototype HTML, I think the accessibility audit would pick up an issue with the prototype too.