### PR TITLE
DSFAAP-808: pin to ubuntu 22.04

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,7 +21,7 @@ jobs:
   build:
     if: github.run_number != 1
     name: CDP-build-workflow
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Check out code
         uses: actions/checkout@v4


### PR DESCRIPTION
Similar to the current check-pull-request.yml job, when we're running directly against chromium, we need to pin it to an older github action runner

Addressing this piece of tech debt is covered in DSFAAP-644 (whose ACs I've changed to cover the publish.yml job too)