### PR TITLE
BAU: allow routing to depend on whole app state

### DIFF
--- a/src/server/common/controller/question-page-controller/question-page-controller.js
+++ b/src/server/common/controller/question-page-controller/question-page-controller.js
@@ -99,7 +99,7 @@ export class QuestionPageController extends GenericPageController {
       [this.page.questionKey]: answer.toState()
     })
 
-    const nextPage = this.page.nextPage(answer)
+    const nextPage = this.page.nextPage(answer, applicationState)
 
     if (nextPage instanceof ExitPage) {
       return h.redirect(nextPage.urlPath)

--- a/src/server/common/model/page/question-page-model.js
+++ b/src/server/common/model/page/question-page-model.js
@@ -1,8 +1,9 @@
-/** @import { AnswerModel, AnswerModelClass } from '../answer/answer-model.js' */
-/** @import { AnswerErrors } from "~/src/server/common/model/answer/validation.js" */
-
 import { NotImplementedError } from '../../helpers/not-implemented-error.js'
 import { Page } from './page-model.js'
+
+/** @import { AnswerModel, AnswerModelClass } from '../answer/answer-model.js' */
+/** @import { AnswerErrors } from "~/src/server/common/model/answer/validation.js" */
+/** @import { RawApplicationState } from '../state/state-manager.js' */
 
 /**
  * @template AnswerPayload
@@ -33,10 +34,11 @@ export class QuestionPage extends Page {
   // eslint-disable-next-line jsdoc/require-returns-check
   /**
    * @param {AnswerModel} _answer
+   * @param {RawApplicationState} [_state]
    * @returns {Page | QuestionPage}
    */
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  nextPage(_answer) {
+  nextPage(_answer, _state) {
     throw new NotImplementedError()
   }
 }


### PR DESCRIPTION
In Release 2, we have some pages that show up depending on *both* the answer to the current question and prior application state.

To facilitate this, routing decisions need to know about both:
- the immediate answer given
- the historical answers given

For instance, after the origin type question, the user is routed to a different CPH number & Address page depending on whether you're going on the premises or off the premises.