### PR TITLE
DSFAAP-853: Allow dynamic radio button configuration & implement routing for origin type

### DIFF
--- a/src/server/common/model/answer/origin-type/origin-type.js
+++ b/src/server/common/model/answer/origin-type/origin-type.js
@@ -1,10 +1,23 @@
 import { RadioButtonAnswer } from '../radio-button/radio-button.js'
 /** @import {RadioButtonConfig} from '../radio-button/radio-button.js' */
+/** @import {RawApplicationState} from '~/src/server/common/model/state/state-manager.js' */
 
 /**
  * export @typedef {'tb-restricted-farm' | 'afu' | 'other'} OriginTypeData
  * @typedef {{ originType: OriginTypeData }} OriginTypePayload
  */
+
+/**
+ * @param {RawApplicationState} app
+ * @returns boolean
+ */
+const isOnToTheFarm = (app) => app.origin?.onOffFarm === 'on'
+
+/**
+ * @param {RawApplicationState} app
+ * @returns boolean
+ */
+const isNotOnToTheFarm = (app) => app.origin?.onOffFarm !== 'on'
 
 /** @augments {RadioButtonAnswer<OriginTypePayload>} */
 export class OriginTypeAnswer extends RadioButtonAnswer {
@@ -12,12 +25,24 @@ export class OriginTypeAnswer extends RadioButtonAnswer {
   static config = {
     payloadKey: 'originType',
     options: {
+      market: { label: 'Market', predicate: isOnToTheFarm },
+      'unrestricted-farm': {
+        label: 'Unrestricted farm or premises',
+        predicate: isOnToTheFarm
+      },
       'tb-restricted-farm': { label: 'TB restricted farm' },
       afu: {
         label: 'Approved finishing unit (AFU)',
         hint: 'Including enhanced with grazing (AFUE)'
       },
-      other: { label: 'Another type of premises' }
+      zoo: { label: 'Zoo', predicate: isOnToTheFarm },
+      lab: { label: 'Laboratory', predicate: isOnToTheFarm },
+      'after-import-location': {
+        label: 'Location after animals have been imported',
+        predicate: isOnToTheFarm
+      },
+      'another-origin': { label: 'Another origin', predicate: isOnToTheFarm },
+      other: { label: 'Another type of premises', predicate: isNotOnToTheFarm }
     },
     errors: {
       emptyOptionText: 'Select where the animals are moving from'

--- a/src/server/common/model/answer/origin-type/origin-type.js
+++ b/src/server/common/model/answer/origin-type/origin-type.js
@@ -1,5 +1,5 @@
 import { RadioButtonAnswer } from '../radio-button/radio-button.js'
-/** @import {RadioButtonConfig} from '../radio-button/radio-button.js' */
+/** @import {RadioButtonConfig, RadioButtonConfigFactory} from '../radio-button/radio-button.js' */
 /** @import {RawApplicationState} from '~/src/server/common/model/state/state-manager.js' */
 
 /**
@@ -13,39 +13,41 @@ import { RadioButtonAnswer } from '../radio-button/radio-button.js'
  */
 const isOnToTheFarm = (app) => app.origin?.onOffFarm === 'on'
 
-/**
- * @param {RawApplicationState} app
- * @returns boolean
- */
-const isNotOnToTheFarm = (app) => app.origin?.onOffFarm !== 'on'
+const tbRestrictedOption = { label: 'TB restricted farm' }
+const afuOption = {
+  label: 'Approved finishing unit (AFU)',
+  hint: 'Including enhanced with grazing (AFUE)'
+}
+
+const offFarmOptions = {
+  'tb-restricted-farm': tbRestrictedOption,
+  afu: afuOption,
+  other: { label: 'Another type of premises' }
+}
+
+const onFarmOptions = {
+  market: { label: 'Market' },
+  'unrestricted-farm': {
+    label: 'Unrestricted farm or premises'
+  },
+  'tb-restricted-farm': tbRestrictedOption,
+  afu: afuOption,
+  zoo: { label: 'Zoo' },
+  lab: { label: 'Laboratory' },
+  'after-import-location': {
+    label: 'Location after animals have been imported'
+  },
+  other: { label: 'Another origin' }
+}
 
 /** @augments {RadioButtonAnswer<OriginTypePayload>} */
 export class OriginTypeAnswer extends RadioButtonAnswer {
-  /** @type {RadioButtonConfig} */
-  static config = {
+  /** @type {RadioButtonConfigFactory} */
+  static config = (app) => ({
     payloadKey: 'originType',
-    options: {
-      market: { label: 'Market', predicate: isOnToTheFarm },
-      'unrestricted-farm': {
-        label: 'Unrestricted farm or premises',
-        predicate: isOnToTheFarm
-      },
-      'tb-restricted-farm': { label: 'TB restricted farm' },
-      afu: {
-        label: 'Approved finishing unit (AFU)',
-        hint: 'Including enhanced with grazing (AFUE)'
-      },
-      zoo: { label: 'Zoo', predicate: isOnToTheFarm },
-      lab: { label: 'Laboratory', predicate: isOnToTheFarm },
-      'after-import-location': {
-        label: 'Location after animals have been imported',
-        predicate: isOnToTheFarm
-      },
-      'another-origin': { label: 'Another origin', predicate: isOnToTheFarm },
-      other: { label: 'Another type of premises', predicate: isNotOnToTheFarm }
-    },
+    options: isOnToTheFarm(app) ? onFarmOptions : offFarmOptions,
     errors: {
       emptyOptionText: 'Select where the animals are moving from'
     }
-  }
+  })
 }

--- a/src/server/common/model/answer/origin-type/origin-type.js
+++ b/src/server/common/model/answer/origin-type/origin-type.js
@@ -3,7 +3,7 @@ import { RadioButtonAnswer } from '../radio-button/radio-button.js'
 /** @import {RawApplicationState} from '~/src/server/common/model/state/state-manager.js' */
 
 /**
- * export @typedef {'tb-restricted-farm' | 'afu' | 'other'} OriginTypeData
+ * export @typedef {'tb-restricted-farm' | 'afu' | 'other' | 'market' | 'unrestricted-farm' | 'zoo' | 'lab' | 'after-import-location' } OriginTypeData
  * @typedef {{ originType: OriginTypeData }} OriginTypePayload
  */
 

--- a/src/server/common/model/answer/origin-type/origin-type.test.js
+++ b/src/server/common/model/answer/origin-type/origin-type.test.js
@@ -21,17 +21,46 @@ describe('OriginType', () => {
       'Select where the animals are moving from'
     )
   })
+})
 
-  it('should have the expected options to select from', () => {
-    expect(Object.keys(OriginTypeAnswer.config.options)).toHaveLength(3)
-    expect(OriginTypeAnswer.config.options['tb-restricted-farm'].label).toBe(
+describe('#OriginType.config', () => {
+  it('should have the expected options to select from for off the farm movements', () => {
+    const context = {
+      origin: { onOffFarm: 'off' }
+    }
+    const config = new OriginTypeAnswer(undefined, context).config
+
+    expect(Object.keys(config.options)).toHaveLength(3)
+    expect(config.options['tb-restricted-farm'].label).toBe(
       'TB restricted farm'
     )
-    expect(OriginTypeAnswer.config.options.afu.label).toBe(
-      'Approved finishing unit (AFU)'
+    expect(config.options.afu.label).toBe('Approved finishing unit (AFU)')
+    expect(config.options.other.label).toBe('Another type of premises')
+  })
+
+  it('should have the expected options to select from for on to the farm movements', () => {
+    const context = {
+      origin: { onOffFarm: 'on' }
+    }
+    const config = new OriginTypeAnswer(undefined, context).config
+
+    expect(config.options.market.label).toBe('Market')
+    expect(config.options['unrestricted-farm'].label).toBe(
+      'Unrestricted farm or premises'
     )
-    expect(OriginTypeAnswer.config.options.other.label).toBe(
-      'Another type of premises'
+    expect(config.options['tb-restricted-farm'].label).toBe(
+      'TB restricted farm'
     )
+    expect(config.options.afu.label).toBe('Approved finishing unit (AFU)')
+    expect(config.options.afu.hint).toBe(
+      'Including enhanced with grazing (AFUE)'
+    )
+    expect(config.options.zoo.label).toBe('Zoo')
+    expect(config.options.lab.label).toBe('Laboratory')
+    expect(config.options['after-import-location'].label).toBe(
+      'Location after animals have been imported'
+    )
+    expect(config.options['another-origin'].label).toBe('Another origin')
+    expect(Object.keys(config.options)).toHaveLength(8)
   })
 })

--- a/src/server/common/model/answer/origin-type/origin-type.test.js
+++ b/src/server/common/model/answer/origin-type/origin-type.test.js
@@ -13,11 +13,11 @@ describe('OriginType', () => {
   })
 
   it('should have the right payload key', () => {
-    expect(OriginTypeAnswer.config.payloadKey).toBe('originType')
+    expect(new OriginTypeAnswer().config.payloadKey).toBe('originType')
   })
 
   it('should define the right empty input message', () => {
-    expect(OriginTypeAnswer.config.errors.emptyOptionText).toBe(
+    expect(new OriginTypeAnswer().config.errors.emptyOptionText).toBe(
       'Select where the animals are moving from'
     )
   })
@@ -60,7 +60,7 @@ describe('#OriginType.config', () => {
     expect(config.options['after-import-location'].label).toBe(
       'Location after animals have been imported'
     )
-    expect(config.options['another-origin'].label).toBe('Another origin')
+    expect(config.options.other.label).toBe('Another origin')
     expect(Object.keys(config.options)).toHaveLength(8)
   })
 })

--- a/src/server/common/model/answer/radio-button/radio-button.js
+++ b/src/server/common/model/answer/radio-button/radio-button.js
@@ -107,7 +107,7 @@ export class RadioButtonAnswer extends AnswerModel {
 
   validate() {
     return validateAnswerAgainstSchema(
-      createRadioSchema(this.config),
+      createRadioSchema(filterOptions(this.config, this._context)),
       this._data ?? {}
     )
   }

--- a/src/server/common/model/answer/radio-button/radio-button.js
+++ b/src/server/common/model/answer/radio-button/radio-button.js
@@ -62,7 +62,10 @@ export class RadioButtonAnswer extends AnswerModel {
   // eslint-disable-next-line jsdoc/require-returns-check
   /** @returns {RadioButtonConfig} */
   get config() {
-    return /** @type {any} */ (this.constructor).config
+    return filterOptions(
+      /** @type {any} */ (this.constructor).config,
+      this._context
+    )
   }
 
   // eslint-disable-next-line jsdoc/require-returns-check
@@ -107,7 +110,7 @@ export class RadioButtonAnswer extends AnswerModel {
 
   validate() {
     return validateAnswerAgainstSchema(
-      createRadioSchema(filterOptions(this.config, this._context)),
+      createRadioSchema(this.config),
       this._data ?? {}
     )
   }
@@ -125,10 +128,7 @@ export class RadioButtonAnswer extends AnswerModel {
    * @param {AnswerViewModelOptions} options
    */
   viewModel({ validate, question }) {
-    const { options, payloadKey, layout } = filterOptions(
-      this.config,
-      this._context
-    )
+    const { options, payloadKey, layout } = this.config
     const items = Object.entries(options).map(([key, value]) => ({
       id: key,
       value: key,

--- a/src/server/common/model/answer/radio-button/radio-button.test.js
+++ b/src/server/common/model/answer/radio-button/radio-button.test.js
@@ -313,3 +313,18 @@ describe('RadioButtonAnswer.template', () => {
     expect(radio.template).toBe('model/answer/radio-button/radio-button.njk')
   })
 })
+
+describe('RadioButtonAnswer.context', () => {
+  it('should filter out config options where they do not meet the current preciates', () => {
+    const radio = new TestRadioButtonAnswer(validTestRadio)
+    expect(radio.config.options).toEqual({
+      value_1: { label: 'test_label_1' },
+      value_2: { label: 'test_label_2', hint: 'test_hint_2' }
+    })
+  })
+
+  it('should include config options where predicate matches', () => {
+    const radio = new TestRadioButtonAnswer(validTestRadio, applicationState)
+    expect(radio.config.options).toEqual(TestRadioButtonAnswer.config.options)
+  })
+})

--- a/src/server/common/model/answer/radio-button/radio-button.test.js
+++ b/src/server/common/model/answer/radio-button/radio-button.test.js
@@ -17,20 +17,35 @@ const validTestRadio = {
 const applicationState = { origin: { onOffFarm: 'on' } }
 
 /** @type {RadioButtonConfig} */
-const testRadioConfig = {
+const defaultConfig = {
   payloadKey: 'test_radio',
   options: {
     value_1: { label: 'test_label_1' },
-    value_2: { label: 'test_label_2', hint: 'test_hint_2' },
-    value_3: {
-      label: 'test_label_3',
-      hint: 'test_hint_3',
-      predicate: (/** @type {RawApplicationState} */ app) =>
-        app.origin?.onOffFarm === 'on'
-    }
+    value_2: { label: 'test_label_2', hint: 'test_hint_2' }
   },
   errors: {
     emptyOptionText: 'Select an option'
+  }
+}
+
+const onFarmOptions = {
+  value_1: { label: 'test_label_1' },
+  value_2: { label: 'test_label_2', hint: 'test_hint_2' },
+  value_3: {
+    label: 'test_label_3',
+    hint: 'test_hint_3'
+  }
+}
+
+/**
+ * @param {RawApplicationState} app
+ * @returns {RadioButtonConfig}
+ */
+const testRadioConfig = (app) => {
+  if (app.origin?.onOffFarm === 'on') {
+    return { ...defaultConfig, options: onFarmOptions }
+  } else {
+    return defaultConfig
   }
 }
 
@@ -41,7 +56,7 @@ class TestRadioButtonAnswer extends RadioButtonAnswer {
 class InlineTestRadioButtonAnswer extends RadioButtonAnswer {
   /** @type {RadioButtonConfig} */
   static config = {
-    ...testRadioConfig,
+    ...defaultConfig,
     layout: 'inline'
   }
 }
@@ -82,7 +97,7 @@ describe('RadioButton', () => {
 
       expect(isValid).toBe(false)
       expect(errors.test_radio.text).toBe(
-        testRadioConfig.errors.emptyOptionText
+        testRadioConfig({}).errors.emptyOptionText
       )
     })
 
@@ -95,7 +110,7 @@ describe('RadioButton', () => {
 
       expect(isValid).toBe(false)
       expect(errors.test_radio.text).toBe(
-        testRadioConfig.errors.emptyOptionText
+        testRadioConfig({}).errors.emptyOptionText
       )
     })
 
@@ -108,7 +123,7 @@ describe('RadioButton', () => {
 
       expect(isValid).toBe(false)
       expect(errors.test_radio.text).toBe(
-        testRadioConfig.errors.emptyOptionText
+        testRadioConfig({}).errors.emptyOptionText
       )
     })
 
@@ -325,6 +340,6 @@ describe('RadioButtonAnswer.context', () => {
 
   it('should include config options where predicate matches', () => {
     const radio = new TestRadioButtonAnswer(validTestRadio, applicationState)
-    expect(radio.config.options).toEqual(TestRadioButtonAnswer.config.options)
+    expect(radio.config.options).toEqual(onFarmOptions)
   })
 })

--- a/src/server/common/model/answer/radio-button/radio-button.test.js
+++ b/src/server/common/model/answer/radio-button/radio-button.test.js
@@ -98,6 +98,33 @@ describe('RadioButton', () => {
         testRadioConfig.errors.emptyOptionText
       )
     })
+
+    it('should return false for values that would be valid, but whose predicates fail', () => {
+      const testInstance = new TestRadioButtonAnswer({
+        test_radio: 'value_3'
+      })
+
+      const { isValid, errors } = testInstance.validate()
+
+      expect(isValid).toBe(false)
+      expect(errors.test_radio.text).toBe(
+        testRadioConfig.errors.emptyOptionText
+      )
+    })
+
+    it('should return true or values that are only valid because their predicates pass', () => {
+      const testInstance = new TestRadioButtonAnswer(
+        {
+          test_radio: 'value_3'
+        },
+        applicationState
+      )
+
+      const { isValid, errors } = testInstance.validate()
+
+      expect(isValid).toBe(true)
+      expect(errors).toEqual({})
+    })
   })
 
   describe('#RadioButton.toState', () => {

--- a/src/server/common/model/page/question-page-model.js
+++ b/src/server/common/model/page/question-page-model.js
@@ -34,11 +34,11 @@ export class QuestionPage extends Page {
   // eslint-disable-next-line jsdoc/require-returns-check
   /**
    * @param {AnswerModel} _answer
-   * @param {RawApplicationState} [_state]
+   * @param {RawApplicationState} [_context]
    * @returns {Page | QuestionPage}
    */
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  nextPage(_answer, _state) {
+  nextPage(_answer, _context) {
     throw new NotImplementedError()
   }
 }

--- a/src/server/common/model/section/section-model/section-model.js
+++ b/src/server/common/model/section/section-model/section-model.js
@@ -112,7 +112,7 @@ export class SectionModel {
         break
       }
 
-      page = page.nextPage(answer)
+      page = page.nextPage(answer, data)
     }
 
     if (!(page instanceof QuestionPage)) {

--- a/src/server/origin/country/index.js
+++ b/src/server/origin/country/index.js
@@ -1,0 +1,8 @@
+import { Page } from '~/src/server/common/model/page/page-model.js'
+
+export class CountryPage extends Page {
+  urlPath = '/origin/country'
+  sectionKey = 'origin'
+}
+
+export const countryPage = new CountryPage()

--- a/src/server/origin/fifty-percent-warning/index.js
+++ b/src/server/origin/fifty-percent-warning/index.js
@@ -1,0 +1,8 @@
+import { Page } from '~/src/server/common/model/page/page-model.js'
+
+export class FiftyPercentWarningPage extends Page {
+  urlPath = '/origin/fifty-percent-warning'
+  sectionKey = 'origin'
+}
+
+export const fiftyPercentWarningPage = new FiftyPercentWarningPage()

--- a/src/server/origin/origin-farm-cph/index.js
+++ b/src/server/origin/origin-farm-cph/index.js
@@ -1,0 +1,7 @@
+import { Page } from '../../common/model/page/page-model.js'
+
+export class OriginFarmCphPage extends Page {
+  urlPath = '/origin/origin-farm-cph'
+  sectionKey = 'origin'
+}
+export const originFarmCphPage = new OriginFarmCphPage()

--- a/src/server/origin/origin-type/index.js
+++ b/src/server/origin/origin-type/index.js
@@ -4,6 +4,8 @@ import { cphNumberPage } from '~/src/server/origin/cph-number/index.js'
 import { OriginTypeAnswer } from '../../common/model/answer/origin-type/origin-type.js'
 import { exitPagePremisesType } from '../premises-type-exit-page/index.js'
 import { countryPage } from '../country/index.js'
+import { originFarmCphPage } from '../origin-farm-cph/index.js'
+import { fiftyPercentWarningPage } from '../fifty-percent-warning/index.js'
 
 /** @import { AnswerErrors } from "~/src/server/common/model/answer/validation.js" */
 /** @import { AnswerModel } from "~/src/server/common/model/answer/answer-model.js" */
@@ -18,16 +20,23 @@ export class OriginTypePage extends QuestionPage {
   Answer = OriginTypeAnswer
 
   /**
-   * @param {AnswerModel} answer
+   * @param {OriginTypeAnswer} answer
    * @param {RawApplicationState} context
    */
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   nextPage(answer, context) {
-    if (answer.value === 'after-import-location') {
+    const isOnFarm = context.origin?.onOffFarm === 'on'
+    if (isOnFarm && answer.value === 'after-import-location') {
       return countryPage
+    }
+    if (isOnFarm && ['market', 'unrestricted-farm'].includes(answer.value)) {
+      return fiftyPercentWarningPage
     }
     if (answer.value === 'other') {
       return exitPagePremisesType
+    }
+    if (isOnFarm) {
+      return originFarmCphPage
     }
     return cphNumberPage
   }

--- a/src/server/origin/origin-type/index.js
+++ b/src/server/origin/origin-type/index.js
@@ -1,16 +1,13 @@
-/**
- * Sets up the routes used in the origin type page.
- * These routes are registered in src/server/router.js.
- */
-
 import { QuestionPage } from '../../common/model/page/question-page-model.js'
 import { QuestionPageController } from '../../common/controller/question-page-controller/question-page-controller.js'
 import { cphNumberPage } from '~/src/server/origin/cph-number/index.js'
 import { OriginTypeAnswer } from '../../common/model/answer/origin-type/origin-type.js'
 import { exitPagePremisesType } from '../premises-type-exit-page/index.js'
+import { countryPage } from '../country/index.js'
 
 /** @import { AnswerErrors } from "~/src/server/common/model/answer/validation.js" */
 /** @import { AnswerModel } from "~/src/server/common/model/answer/answer-model.js" */
+/** @import { RawApplicationState } from '../../common/model/state/state-manager.js' */
 
 export class OriginTypePage extends QuestionPage {
   urlPath = '/origin/type-of-origin'
@@ -20,9 +17,15 @@ export class OriginTypePage extends QuestionPage {
 
   Answer = OriginTypeAnswer
 
-  /** @param {AnswerModel} answer */
+  /**
+   * @param {AnswerModel} answer
+   * @param {RawApplicationState} context
+   */
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  nextPage(answer) {
+  nextPage(answer, context) {
+    if (answer.value === 'after-import-location') {
+      return countryPage
+    }
     if (answer.value === 'other') {
       return exitPagePremisesType
     }

--- a/src/server/origin/origin-type/index.js
+++ b/src/server/origin/origin-type/index.js
@@ -26,17 +26,19 @@ export class OriginTypePage extends QuestionPage {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   nextPage(answer, context) {
     const isOnFarm = context.origin?.onOffFarm === 'on'
-    if (isOnFarm && answer.value === 'after-import-location') {
-      return countryPage
+
+    if (isOnFarm) {
+      if (answer.value === 'after-import-location') {
+        return countryPage
+      }
+      if (['market', 'unrestricted-farm'].includes(answer.value)) {
+        return fiftyPercentWarningPage
+      }
+      return originFarmCphPage
     }
-    if (isOnFarm && ['market', 'unrestricted-farm'].includes(answer.value)) {
-      return fiftyPercentWarningPage
-    }
+
     if (answer.value === 'other') {
       return exitPagePremisesType
-    }
-    if (isOnFarm) {
-      return originFarmCphPage
     }
     return cphNumberPage
   }

--- a/src/server/origin/origin-type/index.test.js
+++ b/src/server/origin/origin-type/index.test.js
@@ -93,25 +93,37 @@ describe('#OriginPage.nextPage', () => {
   describe('On to the farm', () => {
     const context = { origin: { onOffFarm: 'on' } }
 
-    /** @type {OriginTypeData[]} */
-    const fiftyPercentOriginTypes = ['market', 'unrestricted-farm']
+    const fiftyPercentOriginTypes = ['market', 'unrestricted-farm'].map((v) => [
+      v
+    ])
 
-    it.each([fiftyPercentOriginTypes])(
+    it.each(fiftyPercentOriginTypes)(
       `should return 50% warning page for ${fiftyPercentOriginTypes.join(', ')}`,
       (originType) => {
-        const answer = new OriginTypeAnswer({ originType }, context)
+        const answer = new OriginTypeAnswer(
+          { originType: /** @type {OriginTypeData} */ (originType) },
+          context
+        )
         const nextPage = page.nextPage(answer, context)
         expect(nextPage).toBe(fiftyPercentWarningPage)
       }
     )
 
-    /** @type {OriginTypeData[]} */
-    const cphOriginTypes = ['tb-restricted-farm', 'afu', 'zoo', 'lab', 'other']
+    const cphOriginTypes = [
+      'tb-restricted-farm',
+      'afu',
+      'zoo',
+      'lab',
+      'other'
+    ].map((v) => [v])
 
-    it.each([cphOriginTypes])(
+    it.each(cphOriginTypes)(
       `should return cphNumberPage for ${cphOriginTypes.join(', ')}`,
       (originType) => {
-        const answer = new OriginTypeAnswer({ originType }, context)
+        const answer = new OriginTypeAnswer(
+          { originType: /** @type {OriginTypeData} */ (originType) },
+          context
+        )
         const nextPage = page.nextPage(answer, context)
         expect(nextPage).toBe(originFarmCphPage)
       }

--- a/src/server/origin/origin-type/index.test.js
+++ b/src/server/origin/origin-type/index.test.js
@@ -3,8 +3,10 @@ import { OriginTypeAnswer } from '../../common/model/answer/origin-type/origin-t
 import { cphNumberPage } from '../cph-number/index.js'
 import { exitPagePremisesType } from '../premises-type-exit-page/index.js'
 import { describePageSnapshot } from '../../common/test-helpers/snapshot-page.js'
+import { countryPage } from '../country/index.js'
 
 /** @import { PluginBase, PluginNameVersion } from '@hapi/hapi' */
+/** @import { OriginTypeData } from '../../common/model/answer/origin-type/origin-type.js' */
 
 const sectionKey = 'origin'
 const question = 'What type of premises are the animals moving off?'
@@ -12,13 +14,9 @@ const questionKey = 'originType'
 const view = 'common/model/page/question-page.njk'
 const pageUrl = '/origin/type-of-origin'
 
+const page = new OriginTypePage()
+
 describe('OriginTypePage', () => {
-  let page
-
-  beforeEach(() => {
-    page = new OriginTypePage()
-  })
-
   it('should have the correct urlPath', () => {
     expect(page.urlPath).toBe(pageUrl)
   })
@@ -47,24 +45,6 @@ describe('OriginTypePage', () => {
     expect(originTypePage).toBeInstanceOf(OriginTypePage)
   })
 
-  it('nextPage should return cphNumberPage when answer is "tb-restricted-farm"', () => {
-    const answer = { value: 'tb-restricted-farm' }
-    const nextPage = page.nextPage(answer)
-    expect(nextPage).toBe(cphNumberPage)
-  })
-
-  it('nextPage should return cphNumberPage when answer is "afu"', () => {
-    const answer = { value: 'afu' }
-    const nextPage = page.nextPage(answer)
-    expect(nextPage).toBe(cphNumberPage)
-  })
-
-  it('nextPage should return exitPagePremisesType when answer is "other"', () => {
-    const answer = { value: 'other' }
-    const nextPage = page.nextPage(answer)
-    expect(nextPage).toBe(exitPagePremisesType)
-  })
-
   it('should export originType as a plugin', () => {
     expect(originType).toHaveProperty('plugin')
     const plugin = /** @type {PluginBase<void> & PluginNameVersion} */ (
@@ -79,5 +59,69 @@ describe('OriginTypePage', () => {
     describes: 'OriginTypePage.content',
     it: 'should render expected response and content',
     pageUrl
+  })
+})
+
+describe('#OriginPage.nextPage', () => {
+  describe('Off the farm', () => {
+    const context = { origin: { onOffFarm: 'off' } }
+
+    it('should return cphNumberPage when answer is "tb-restricted-farm"', () => {
+      const answer = new OriginTypeAnswer(
+        { originType: 'tb-restricted-farm' },
+        context
+      )
+      const nextPage = page.nextPage(answer, context)
+      expect(nextPage).toBe(cphNumberPage)
+    })
+
+    it('nextPage should return cphNumberPage when answer is "afu"', () => {
+      const answer = new OriginTypeAnswer({ originType: 'afu' }, context)
+      const nextPage = page.nextPage(answer, context)
+      expect(nextPage).toBe(cphNumberPage)
+    })
+
+    it('nextPage should return exitPagePremisesType when answer is "other"', () => {
+      const answer = new OriginTypeAnswer({ originType: 'other' }, context)
+      const nextPage = page.nextPage(answer, context)
+      expect(nextPage).toBe(exitPagePremisesType)
+    })
+  })
+
+  describe('On to the farm', () => {
+    const context = { origin: { onOffFarm: 'on' } }
+
+    /** @type {OriginTypeData[]} */
+    const fiftyPercentOriginTypes = ['market', 'unrestricted-farm']
+
+    it.each([fiftyPercentOriginTypes])(
+      `should return 50% warning page for ${fiftyPercentOriginTypes.join(', ')}`,
+      (originType) => {
+        const answer = new OriginTypeAnswer({ originType }, context)
+        const nextPage = page.nextPage(answer, context)
+        expect(nextPage).toBe(cphNumberPage)
+      }
+    )
+
+    /** @type {OriginTypeData[]} */
+    const cphOriginTypes = ['tb-restricted-farm', 'afu', 'zoo', 'lab', 'other']
+
+    it.each([cphOriginTypes])(
+      `should return cphNumberPage for ${cphOriginTypes.join(', ')}`,
+      (originType) => {
+        const answer = new OriginTypeAnswer({ originType }, context)
+        const nextPage = page.nextPage(answer, context)
+        expect(nextPage).toBe(cphNumberPage)
+      }
+    )
+
+    it('nextPage should return origin country when moving on from an import', () => {
+      const answer = new OriginTypeAnswer(
+        { originType: 'after-import-location' },
+        context
+      )
+      const nextPage = page.nextPage(answer, context)
+      expect(nextPage).toBe(countryPage)
+    })
   })
 })

--- a/src/server/origin/origin-type/index.test.js
+++ b/src/server/origin/origin-type/index.test.js
@@ -4,6 +4,8 @@ import { cphNumberPage } from '../cph-number/index.js'
 import { exitPagePremisesType } from '../premises-type-exit-page/index.js'
 import { describePageSnapshot } from '../../common/test-helpers/snapshot-page.js'
 import { countryPage } from '../country/index.js'
+import { originFarmCphPage } from '../origin-farm-cph/index.js'
+import { fiftyPercentWarningPage } from '../fifty-percent-warning/index.js'
 
 /** @import { PluginBase, PluginNameVersion } from '@hapi/hapi' */
 /** @import { OriginTypeData } from '../../common/model/answer/origin-type/origin-type.js' */
@@ -99,7 +101,7 @@ describe('#OriginPage.nextPage', () => {
       (originType) => {
         const answer = new OriginTypeAnswer({ originType }, context)
         const nextPage = page.nextPage(answer, context)
-        expect(nextPage).toBe(cphNumberPage)
+        expect(nextPage).toBe(fiftyPercentWarningPage)
       }
     )
 
@@ -111,7 +113,7 @@ describe('#OriginPage.nextPage', () => {
       (originType) => {
         const answer = new OriginTypeAnswer({ originType }, context)
         const nextPage = page.nextPage(answer, context)
-        expect(nextPage).toBe(cphNumberPage)
+        expect(nextPage).toBe(originFarmCphPage)
       }
     )
 

--- a/user-journey-tests/helpers/testHelpers/checkAnswers.js
+++ b/user-journey-tests/helpers/testHelpers/checkAnswers.js
@@ -18,12 +18,9 @@ export const validateOnOffFarm = async (changeLink, valueElement, nextPage) => {
   await selectElement(changeLink)
 
   await expect(toFromFarmPage.offThefarmRadio).toBeSelected()
-  await toFromFarmPage.selectOnFarmAndContinue(nextPage)
+  await toFromFarmPage.selectOffFarmAndContinue(nextPage)
 
-  await validateElementVisibleAndText(
-    valueElement,
-    'On to the farm or premises'
-  )
+  await validateElementVisibleAndText(valueElement, 'Off the farm or premises')
 }
 
 export const validateOriginType = async (

--- a/user-journey-tests/page-objects/origin/fiftyPercentPage.js
+++ b/user-journey-tests/page-objects/origin/fiftyPercentPage.js
@@ -1,0 +1,7 @@
+import { Page } from '../page.js'
+
+class FiftyPercentPage extends Page {
+  pagePath = 'origin/fifty-percent-warning'
+}
+
+export default new FiftyPercentPage()

--- a/user-journey-tests/page-objects/origin/onFarmCPHPage.js
+++ b/user-journey-tests/page-objects/origin/onFarmCPHPage.js
@@ -1,0 +1,7 @@
+import { Page } from '../page.js'
+
+class OnFarmCPHPage extends Page {
+  pagePath = 'origin/origin-farm-cph'
+}
+
+export default new OnFarmCPHPage()

--- a/user-journey-tests/page-objects/origin/originCountryPage.js
+++ b/user-journey-tests/page-objects/origin/originCountryPage.js
@@ -1,0 +1,7 @@
+import { Page } from '../page.js'
+
+class OriginCountryPage extends Page {
+  pagePath = 'origin/country'
+}
+
+export default new OriginCountryPage()

--- a/user-journey-tests/page-objects/origin/originTypePage.js
+++ b/user-journey-tests/page-objects/origin/originTypePage.js
@@ -1,7 +1,7 @@
 import { $ } from '@wdio/globals'
 
 import { Page } from '../page.js'
-import { waitForPagePath } from '../../helpers/page.js'
+import { waitForElement, waitForPagePath } from '../../helpers/page.js'
 
 const pageHeadingAndTitle = 'What type of premises are the animals moving off?'
 
@@ -11,12 +11,32 @@ class OriginTypePage extends Page {
   pageTitle = pageHeadingAndTitle
   emptyErrorMessage = 'Select where the animals are moving from'
 
+  get marketRadio() {
+    return $('input[value="market"]')
+  }
+
+  get unrestrictedFarmRadio() {
+    return $('#unrestricted-farm')
+  }
+
   get tbRestrictedFarmRadio() {
-    return $('#originType')
+    return $('[value="tb-restricted-farm"]')
   }
 
   get approvedFinishingUnitRadio() {
     return $('#afu')
+  }
+
+  get zooRadio() {
+    return $('#zoo')
+  }
+
+  get labRadio() {
+    return $('#lab')
+  }
+
+  get afterImportRadio() {
+    return $('#after-import-location')
   }
 
   get anotherTypeOfPremisesRadio() {
@@ -31,6 +51,20 @@ class OriginTypePage extends Page {
     return $('#originType-error')
   }
 
+  async verifyOffFarmVersion() {
+    await waitForElement(this.tbRestrictedFarmRadio, { visible: false })
+    await waitForElement(this.approvedFinishingUnitRadio, { visible: false })
+    await waitForElement(this.anotherTypeOfPremisesRadio, { visible: false })
+  }
+
+  async verifyOnFarmVersion() {
+    await waitForElement(this.marketRadio, { visible: false })
+    await waitForElement(this.zooRadio, { visible: false })
+    await waitForElement(this.labRadio, { visible: false })
+    await waitForElement(this.afterImportRadio, { visible: false })
+    await this.verifyOffFarmVersion()
+  }
+
   async selectTBRestrictedFarmAndContinue(nextPage) {
     await super.selectRadioAndContinue(this.tbRestrictedFarmRadio)
     await waitForPagePath(nextPage.pagePath)
@@ -43,6 +77,31 @@ class OriginTypePage extends Page {
 
   async selectAnotherTypeOfPremisesAndContinue(nextPage) {
     await super.selectRadioAndContinue(this.anotherTypeOfPremisesRadio)
+    await waitForPagePath(nextPage.pagePath)
+  }
+
+  async selectMarketAndContinue(nextPage) {
+    await super.selectRadioAndContinue(this.marketRadio)
+    await waitForPagePath(nextPage.pagePath)
+  }
+
+  async selectZooAndContinue(nextPage) {
+    await super.selectRadioAndContinue(this.zooRadio)
+    await waitForPagePath(nextPage.pagePath)
+  }
+
+  async selectUnrestrictedAndContinue(nextPage) {
+    await super.selectRadioAndContinue(this.unrestrictedFarmRadio)
+    await waitForPagePath(nextPage.pagePath)
+  }
+
+  async selectLabAndContinue(nextPage) {
+    await super.selectRadioAndContinue(this.labRadio)
+    await waitForPagePath(nextPage.pagePath)
+  }
+
+  async selectAfterImportAndContinue(nextPage) {
+    await super.selectRadioAndContinue(this.afterImportRadio)
     await waitForPagePath(nextPage.pagePath)
   }
 

--- a/user-journey-tests/specs/origin/toFromFarm.spec.js
+++ b/user-journey-tests/specs/origin/toFromFarm.spec.js
@@ -2,6 +2,9 @@ import { browser, expect } from '@wdio/globals'
 import { waitForPagePath } from '../../helpers/page.js'
 import toFromFarmPage from '../../page-objects/origin/toFromFarmPage.js'
 import originTypePage from '../../page-objects/origin/originTypePage.js'
+import fiftyPercentPage from '../../page-objects/origin/fiftyPercentPage.js'
+import onFarmCPHPage from '../../page-objects/origin/onFarmCPHPage.js'
+import originCountryPage from '../../page-objects/origin/originCountryPage.js'
 
 describe('To from farm page test', () => {
   beforeEach('Reset browser state and navigate to page', async () => {
@@ -15,16 +18,33 @@ describe('To from farm page test', () => {
 
   it('Should select on the farm radio and continue', async () => {
     await toFromFarmPage.selectOnFarmAndContinue(originTypePage)
+    await originTypePage.verifyOnFarmVersion()
   })
 
   it('Should choose an option and check its maintained', async () => {
     await toFromFarmPage.selectOffFarmAndContinue(originTypePage)
     await originTypePage.verifyPageHeadingAndTitle()
+    await originTypePage.verifyOffFarmVersion()
     await browser.back()
 
     await browser.refresh()
     await waitForPagePath(toFromFarmPage.pagePath)
 
     await expect(toFromFarmPage.offThefarmRadio).toBeSelected()
+  })
+
+  it('Should verify fifty percent page navigation', async () => {
+    await toFromFarmPage.selectOnFarmAndContinue(originTypePage)
+    await originTypePage.selectMarketAndContinue(fiftyPercentPage)
+  })
+
+  it('Should verify on farm cph page', async () => {
+    await toFromFarmPage.selectOnFarmAndContinue(originTypePage)
+    await originTypePage.selectZooAndContinue(onFarmCPHPage)
+  })
+
+  it('Should verify country page', async () => {
+    await toFromFarmPage.selectOnFarmAndContinue(originTypePage)
+    await originTypePage.selectAfterImportAndContinue(originCountryPage)
   })
 })


### PR DESCRIPTION
I've added the option to pass a config factory.  This allows us to:

1. change the *option* text, without changing the value
2. change the *order* of options, even when options are the same

The first one is necessary for this ticket - where the concept of
'other' premise has an updated label (and yet we're implementing this in
a way that preserves the current implementation that's accessible in
live).

The second one will be necessary for future tickets (specifically
destination premises type), where the order for each option has been
user test specifically & helps users answer the question.