### PR TITLE
DSFAAP-924: prevent 5xx when rendering HTML for checkbox state

### DIFF
--- a/src/server/common/model/answer/checkbox/__snapshots__/checkbox.test.js.snap
+++ b/src/server/common/model/answer/checkbox/__snapshots__/checkbox.test.js.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CheckboxAnswer.html should return the payload with HTML 1`] = `"Badger proof fencing, such as solid aluminium sheeted gates, aluminium sheeting on rail fences, retractable electric fences<br /><br />Limiting access to badger latrines and setts"`;

--- a/src/server/common/model/answer/checkbox/checkbox.js
+++ b/src/server/common/model/answer/checkbox/checkbox.js
@@ -13,7 +13,7 @@ import { validateAnswerAgainstSchema } from '../validation.js'
 const createCheckboxSchema = (config) => {
   const optionSchema = Joi.string().valid(...Object.keys(config.options))
 
-  let optionsSchema = Joi.array().items(optionSchema)
+  let optionsSchema = Joi.array().required().items(optionSchema)
 
   if (config.validation.empty) {
     const emptyOptionText = config.validation.empty.message
@@ -81,7 +81,7 @@ export class CheckboxAnswer extends AnswerModel {
   }
 
   get html() {
-    const data = this._data?.[this.config.payloadKey]
+    const data = ensureArray(this._data?.[this.config.payloadKey])
 
     if (data.length === 0) {
       return 'None'
@@ -141,10 +141,9 @@ export class CheckboxAnswer extends AnswerModel {
   }
 
   validate() {
+    const data = this._data?.[this.config.payloadKey]
     return validateAnswerAgainstSchema(createCheckboxSchema(this.config), {
-      [this.config.payloadKey]: ensureArray(
-        this._data?.[this.config.payloadKey]
-      )
+      [this.config.payloadKey]: ensureArray(data)
     })
   }
 

--- a/src/server/common/model/answer/checkbox/checkbox.test.js
+++ b/src/server/common/model/answer/checkbox/checkbox.test.js
@@ -79,7 +79,9 @@ describe('#Checkbox.validate', () => {
   })
 
   it('should return false for empty', () => {
-    const { isValid, errors } = new TestCheckboxAnswer(undefined).validate()
+    const { isValid, errors } = new TestCheckboxAnswer({
+      test_checkbox: []
+    }).validate()
 
     expect(isValid).toBe(false)
     expect(errors.test_checkbox.text).toBe(checkboxEmptyError)
@@ -97,6 +99,14 @@ describe('#Checkbox.validate', () => {
 
   describe('TestCheckboxAnswerAllOptional', () => {
     it('should not error if no options are selected', () => {
+      const { isValid } = new TestCheckboxAnswerAllOptional({
+        test_checkbox: []
+      }).validate()
+
+      expect(isValid).toBe(true)
+    })
+
+    it('should not error if the question has not yet been answered', () => {
       const { isValid } = new TestCheckboxAnswerAllOptional(
         undefined
       ).validate()
@@ -165,6 +175,28 @@ describe('CheckboxAnswer.template', () => {
   it('should return the radio button model template', () => {
     const radio = new TestCheckboxAnswer(validTestCheckbox)
     expect(radio.template).toBe('model/answer/checkbox/checkbox.njk')
+  })
+})
+
+describe('CheckboxAnswer.html', () => {
+  it('should return the payload with HTML', () => {
+    const checkbox = new TestCheckboxAnswer({
+      test_checkbox: ['badgerProofFencing', 'limitAccessToBadgerHabitat']
+    })
+
+    expect(checkbox.html).toMatchSnapshot()
+  })
+
+  it('should return None for undefined state', () => {
+    const checkbox = new TestCheckboxAnswer(undefined)
+    expect(checkbox.html).toBe('None')
+  })
+
+  it('should return None for an empty list', () => {
+    const checkbox = new TestCheckboxAnswer({
+      test_checkbox: []
+    })
+    expect(checkbox.html).toBe('None')
   })
 })
 


### PR DESCRIPTION
Because of the way our models are constructed & the way that the browser delivers payloads that are, I’m able to introduce this improvement to the journey fairly easily: 

Reproduction steps

- start the Biosecurity details 
- answer all questions until getting to the /biosecurity/badgers checkbox 
- visit the /task-list 
- click on the Biosecurity details link

**Result**

- task is marked as complete
- taken to /biosecurity/check-answers
- /biosecurity/check-answers renders with None for the answer to badgers