### PR TITLE
BAU: Do state updates in the StateManager

### DIFF
--- a/src/server/biosecurity-map/upload-plan/index.js
+++ b/src/server/biosecurity-map/upload-plan/index.js
@@ -66,10 +66,8 @@ export class UploadPlanController extends QuestionPageController {
       metadata: data
     })
 
-    req.yar.set(this.page.sectionKey, {
-      ...req.yar.get(this.page.sectionKey),
-      [this.page.questionKey]: answer.toState()
-    })
+    const state = new StateManager(req)
+    state.set(this.page, answer)
 
     h.headers = {
       'Cache-Control': 'no-store, must-revalidate, max-age=0',

--- a/src/server/biosecurity-map/upload-progress/index.js
+++ b/src/server/biosecurity-map/upload-progress/index.js
@@ -50,10 +50,8 @@ export class UploadProgressController extends QuestionPageController {
       status
     })
 
-    req.yar.set(this.page.sectionKey, {
-      ...req.yar.get(this.page.sectionKey),
-      [this.page.questionKey]: newAnswer.toState()
-    })
+    const state = new StateManager(req)
+    state.set(this.page, newAnswer)
 
     const { isValid } = newAnswer.validate()
     if (!isValid) {

--- a/src/server/common/controller/question-page-controller/question-page-controller.js
+++ b/src/server/common/controller/question-page-controller/question-page-controller.js
@@ -95,10 +95,8 @@ export class QuestionPageController extends GenericPageController {
       })
     }
 
-    req.yar.set(this.page.sectionKey, {
-      ...req.yar.get(this.page.sectionKey),
-      [this.page.questionKey]: answer.toState()
-    })
+    const state = new StateManager(req)
+    state.set(this.page, answer)
 
     const nextPage = this.page.nextPage(answer, applicationState)
 

--- a/src/server/common/model/state/state-manager.js
+++ b/src/server/common/model/state/state-manager.js
@@ -1,4 +1,6 @@
 /** @import {Request} from "@hapi/hapi/lib/types/request.js" */
+/** @import { QuestionPage } from "../page/question-page-model.js" */
+/** @import { AnswerModel } from "../answer/answer-model.js" */
 
 /**
  * @typedef {Record<string, any>} RawSectionState
@@ -27,5 +29,16 @@ export class StateManager {
         .map((key) => [key, this._request.yar.get(key)])
         .filter((entry) => entry.at(1) !== null)
     )
+  }
+
+  /**
+   * @param {QuestionPage} page
+   * @param {AnswerModel<any>} answer
+   */
+  set(page, answer) {
+    this._request.yar.set(page.sectionKey, {
+      ...this._request.yar.get(page.sectionKey),
+      [page.questionKey]: answer.toState()
+    })
   }
 }

--- a/src/server/common/model/state/state-manager.test.js
+++ b/src/server/common/model/state/state-manager.test.js
@@ -1,4 +1,6 @@
+import { onOffFarmPage } from '~/src/server/origin/on-off-farm/index.js'
 import { StateManager } from './state-manager.js'
+import { originTypePage } from '~/src/server/origin/origin-type/index.js'
 
 /** @import {RawApplicationState} from './state-manager.js' */
 
@@ -36,11 +38,12 @@ const validState = {
  */
 const testRequest = (state) => ({
   yar: {
-    get: jest.fn().mockImplementation((key) => state[key])
+    get: jest.fn().mockImplementation((key) => state[key]),
+    set: jest.fn()
   }
 })
 
-describe('StateManager', () => {
+describe('StateManager.toState', () => {
   it('extracts the raw application state from a request', () => {
     const request = testRequest(validState)
     const state = new StateManager(request)
@@ -64,5 +67,30 @@ describe('StateManager', () => {
     const request = testRequest({ ...validState, someOtherKey: {} })
     const state = new StateManager(request)
     expect(state.toState()).toEqual(validState)
+  })
+})
+
+describe('StateManager.update', () => {
+  it('extracts the raw application state from a request', () => {
+    const request = testRequest(validState)
+    const state = new StateManager(request)
+
+    state.set(onOffFarmPage, new onOffFarmPage.Answer({ onOffFarm: 'off' }))
+
+    expect(request.yar.set).toHaveBeenCalledWith(onOffFarmPage.sectionKey, {
+      onOffFarm: 'off'
+    })
+  })
+
+  it('should preserve the existing state', () => {
+    const request = testRequest(validState)
+    const state = new StateManager(request)
+
+    state.set(originTypePage, new originTypePage.Answer({ originType: 'afu' }))
+
+    expect(request.yar.set).toHaveBeenCalledWith(onOffFarmPage.sectionKey, {
+      onOffFarm: 'on',
+      originType: 'afu'
+    })
   })
 })

--- a/src/server/licence/postExitPage/post-exit-page-controller.js
+++ b/src/server/licence/postExitPage/post-exit-page-controller.js
@@ -1,5 +1,6 @@
 import { PageController } from '../../common/controller/page-controller/page-controller.js'
 import { ReceiveMethodAnswer } from '../../common/model/answer/receiveMethod/receiveMethod.js'
+import { StateManager } from '../../common/model/state/state-manager.js'
 import { emailAddressPage } from '../email-address/index.js'
 import { receiveMethodPage } from '../receiveMethod/index.js'
 
@@ -11,10 +12,9 @@ export class PostExitPageController extends PageController {
   handlePost(req, h) {
     const answer = ReceiveMethodAnswer.fromState(req.payload.receiveMethod)
 
-    req.yar.set(receiveMethodPage.sectionKey, {
-      ...req.yar.get(receiveMethodPage.sectionKey),
-      [receiveMethodPage.questionKey]: answer.toState()
-    })
+    const state = new StateManager(req)
+    state.set(receiveMethodPage, answer)
+
     return h.redirect(this.nextPage().urlPath)
   }
 }


### PR DESCRIPTION
The state update operation is dangerous (because you could wipe out the other state in your relevant section), so I'm not keen to repeat it across our codebase.

In upcoming change (to handle pdfs that cannot compress) will introduce another place where we use this pattern, so I wanted to extract it ahead of that.