### PR TITLE
BAU: simplify test login management

### DIFF
--- a/user-journey-tests/helpers/authSessionManager.js
+++ b/user-journey-tests/helpers/authSessionManager.js
@@ -5,7 +5,3 @@ export async function loginAndSaveSession(signInPage) {
 export async function restoreSession() {
   await browser.deleteCookies('session', 'crumb')
 }
-
-export async function restoreSessionAdvanced() {
-  await restoreSession()
-}

--- a/user-journey-tests/helpers/authSessionManager.js
+++ b/user-journey-tests/helpers/authSessionManager.js
@@ -1,69 +1,11 @@
-/* global localStorage, sessionStorage */
-let savedCookies
-let savedLocalStorage
-
 export async function loginAndSaveSession(signInPage) {
   await signInPage.signInUsingTestCredentials()
-
-  savedCookies = await browser.getCookies()
-
-  savedLocalStorage = await browser.execute(() => {
-    const store = {}
-    for (let i = 0; i < localStorage.length; i++) {
-      const key = localStorage.key(i)
-      store[key] = localStorage.getItem(key)
-    }
-    return store
-  })
 }
 
-// This restores all cookie details from previous run (much faster than advanced, use where possible)
 export async function restoreSession() {
-  await browser.url('/')
-
-  for (const cookie of savedCookies) {
-    await browser.setCookies(cookie)
-  }
-
-  await browser.refresh()
-
-  await browser.execute((data) => {
-    for (const key in data) {
-      localStorage.setItem(key, data[key])
-    }
-  }, savedLocalStorage)
-
-  await browser.refresh()
+  await browser.deleteCookies('session', 'crumb')
 }
 
-// This one only restores the certain cookies so that data saved in the app is not retained
 export async function restoreSessionAdvanced() {
-  await browser.url('/')
-
-  // 🔁 Clear existing state before restoring
-  await browser.deleteCookies()
-  await browser.execute(() => {
-    localStorage.clear()
-    sessionStorage.clear()
-  })
-
-  // ✅ Restore saved cookies
-  const authCookiesOnly = savedCookies.filter(
-    (cookie) => ['auth', 'crumb'].includes(cookie.name) // keep only login-relevant cookies
-  )
-
-  for (const cookie of authCookiesOnly) {
-    await browser.setCookies(cookie)
-  }
-
-  await browser.refresh()
-
-  // ✅ Restore saved localStorage (after refresh to avoid overwrite)
-  await browser.execute((data) => {
-    for (const key in data) {
-      localStorage.setItem(key, data[key])
-    }
-  }, savedLocalStorage)
-
-  await browser.refresh()
+  await restoreSession()
 }

--- a/user-journey-tests/specs/destination/destinationAnswers.spec.js
+++ b/user-journey-tests/specs/destination/destinationAnswers.spec.js
@@ -14,7 +14,7 @@ import taskListPage from '../../page-objects/taskListPage.js'
 import signInPage from '../../page-objects/signInPage.js'
 import {
   loginAndSaveSession,
-  restoreSessionAdvanced
+  restoreSession
 } from '../../helpers/authSessionManager.js'
 
 describe('Check your answers test - destination', () => {
@@ -24,7 +24,7 @@ describe('Check your answers test - destination', () => {
   })
 
   beforeEach('Restore session and navigate to page', async () => {
-    await restoreSessionAdvanced()
+    await restoreSession()
     await completeOriginTaskAnswers()
     // await landingPage.navigateToPageAndVerifyTitle()
   })

--- a/user-journey-tests/specs/destination/destinationSelectionOptions.spec.js
+++ b/user-journey-tests/specs/destination/destinationSelectionOptions.spec.js
@@ -7,7 +7,7 @@ import generalLicencePage from '../../page-objects/destination/generalLicencePag
 import signInPage from '../../page-objects/signInPage.js'
 import {
   loginAndSaveSession,
-  restoreSessionAdvanced
+  restoreSession
 } from '../../helpers/authSessionManager.js'
 
 describe('Destination selection options test', () => {
@@ -17,7 +17,7 @@ describe('Destination selection options test', () => {
   })
 
   beforeEach('Restore session', async () => {
-    await restoreSessionAdvanced()
+    await restoreSession()
   })
 
   it('Should verify options when On the farm and AFU IS NOT option selected', async () => {


### PR DESCRIPTION
In the application, there are 4 cookies:

- defra-id-bell
- userSession
- session
- crumb

The login-specific cookies are defra-id-bell and userSession - with userSession being the one that tells the application that the user is successfully signed in.

Session and (to a lesser extent) crumb are the cookies that manage application state and user journey aside from authorisation.

e.g. where are you in the journey, and whether your page submission is believed to be legitimate.

This PR deletes only the application state cookies, keeping the auth ones in place.

Also, by doing this we avoid global state, which opens up to (e.g.) having multiple test accounts with different roles in future, without tests conflicting with each other.