### PR TITLE
DSFAAP-1056: suggested test improvements & refactor

### DIFF
--- a/src/server/common/model/answer/date/date-utils.js
+++ b/src/server/common/model/answer/date/date-utils.js
@@ -9,22 +9,6 @@ export const MONTH_DAYS = 31
 export const YEAR_MONTHS = 12
 
 /**
- * Creates a TZ Date object using the given date
- * @param {Date} inputDate
- */
-export const createTZDate = (inputDate) =>
-  new TZDate(
-    inputDate.getFullYear(),
-    inputDate.getMonth(),
-    inputDate.getDate(),
-    inputDate.getHours(),
-    inputDate.getMinutes(),
-    inputDate.getSeconds(),
-    inputDate.getMilliseconds(),
-    Intl.DateTimeFormat().resolvedOptions().timeZone
-  ).withTimeZone('Europe/London')
-
-/**
  * Converts a DateData object to a TZDate object assuming BST timezone
  * @param {DateData | undefined} date
  */
@@ -42,7 +26,7 @@ export const toBSTDate = (date) => {
  * @returns {number}
  */
 export const differenceInDaysWithToday = (inputDate) => {
-  const currentDate = createTZDate(new Date())
+  const currentDate = new Date()
   const dateToCompare = toBSTDate(inputDate)
 
   return differenceInCalendarDays(currentDate, dateToCompare)

--- a/src/server/common/model/answer/date/date-utils.test.js
+++ b/src/server/common/model/answer/date/date-utils.test.js
@@ -4,7 +4,6 @@ import {
   isFutureDate,
   toBSTDate
 } from './date-utils.js'
-import { subDays } from 'date-fns'
 
 describe('Date Helpers', () => {
   describe('toBSTDate', () => {
@@ -77,94 +76,54 @@ describe('Date Helpers', () => {
   })
 
   describe('differenceInDaysWithToday', () => {
+    beforeEach(() => {
+      jest.useFakeTimers()
+      jest.setSystemTime(new TZDate('2025-04-01T00:00:00', 'Europe/London'))
+    })
+
+    afterAll(jest.useRealTimers)
+
     it('should return a positive number for a past date', () => {
-      const pastDate = { day: '01', month: '01', year: '2000' }
+      const pastDate = { day: '31', month: '03', year: '2025' }
       const difference = differenceInDaysWithToday(pastDate)
-      expect(difference).toBeGreaterThan(0)
+      expect(difference).toBe(1)
     })
 
     it('should return a negative number for a future date', () => {
-      const futureDate = { day: '01', month: '01', year: '3000' }
+      const futureDate = { day: '02', month: '04', year: '2025' }
       const difference = differenceInDaysWithToday(futureDate)
-      expect(difference).toBeLessThan(0)
+      expect(difference).toBe(-1)
     })
 
     it('should return 0 for the current date', () => {
-      const currentDate = new Date()
-      const dateData = {
-        day: currentDate.getUTCDate().toString(),
-        month: (currentDate.getUTCMonth() + 1).toString(),
-        year: currentDate.getUTCFullYear().toString()
-      }
-      const difference = differenceInDaysWithToday(dateData)
+      const currentDate = { day: '01', month: '04', year: '2025' }
+      const difference = differenceInDaysWithToday(currentDate)
       expect(difference).toBe(0)
     })
 
-    describe('when the server is in a different timezone', () => {
-      beforeEach(() => {
-        jest.useFakeTimers()
-      })
+    it('should return 0 if the given date when coverted to UTC is actually the current date', () => {
+      const systemDateTime = new TZDate(
+        '2025-04-01T00:30:00',
+        'Europe/London'
+      ).withTimeZone('UTC')
+      expect(systemDateTime.toISOString()).toBe('2025-03-31T23:30:00.000+00:00')
 
-      afterEach(() => {
-        jest.useRealTimers()
-      })
+      const currentDate = { day: '01', month: '04', year: '2025' }
+      const difference = differenceInDaysWithToday(currentDate)
+      expect(difference).toBe(0)
+    })
 
-      it('should return 0 if the given date when coverted to UTC is actually the current date', () => {
-        const currentDate = new Date()
-        const yesterday = subDays(currentDate, 1)
+    it('should return 1 if the given date when coverted to BST is one day after UTC current date', () => {
+      const systemDateTime = new TZDate(
+        '2025-04-01T00:30:00',
+        'Europe/London'
+      ).withTimeZone('UTC')
+      expect(systemDateTime.toISOString()).toBe('2025-03-31T23:30:00.000+00:00')
 
-        const dateData = {
-          day: currentDate.getUTCDate().toString(),
-          month: (currentDate.getUTCMonth() + 1).toString(),
-          year: currentDate.getUTCFullYear().toString()
-        }
+      const currentDate = { day: '31', month: '03', year: '2025' }
+      const difference = differenceInDaysWithToday(currentDate)
 
-        // setting the system time to a date that is one day before the current date
-        // but in BST timezone it is still in the same date as current date
-        jest.setSystemTime(
-          new Date(
-            Date.UTC(
-              yesterday.getUTCFullYear(),
-              yesterday.getUTCMonth(),
-              yesterday.getUTCDate(),
-              23,
-              30,
-              0,
-              0
-            )
-          )
-        )
-
-        const difference = differenceInDaysWithToday(dateData)
-        expect(difference).toBe(0)
-      })
-
-      it('should return -1 if the given date when coverted to BST is one day before current date', () => {
-        const currentDate = new Date()
-        const yesterday = subDays(currentDate, 1)
-
-        const dateData = {
-          day: currentDate.getUTCDate().toString(),
-          month: (currentDate.getUTCMonth() + 1).toString(),
-          year: currentDate.getUTCFullYear().toString()
-        }
-
-        // setting the system time to a date that is one day before the current date
-        // and in BST timezone it is also one day before the current date
-        jest.setSystemTime(
-          new Date(
-            yesterday.getFullYear(),
-            yesterday.getMonth(),
-            yesterday.getDate(),
-            0,
-            30,
-            0,
-            0
-          )
-        )
-        const difference = differenceInDaysWithToday(dateData)
-        expect(difference).toBe(-1)
-      })
+      expect(difference).toBe(1)
     })
   })
 })

--- a/src/server/common/model/answer/date/date-utils.test.js
+++ b/src/server/common/model/answer/date/date-utils.test.js
@@ -49,26 +49,20 @@ describe('Date Helpers', () => {
     })
 
     it('should return false if current date matches in BST, even UTC-based system time is showing the previous day', () => {
-      const systemDateTime = new TZDate(
-        '2025-04-01T00:30:00',
-        'Europe/London'
-      ).withTimeZone('UTC')
-      expect(systemDateTime.toISOString()).toBe('2025-03-31T23:30:00.000+00:00')
-
-      jest.setSystemTime(systemDateTime)
+      jest.setSystemTime(
+        new TZDate('2025-04-01T00:30:00', 'Europe/London').withTimeZone('UTC')
+      )
+      expect(new Date().toISOString()).toBe('2025-03-31T23:30:00.000Z')
 
       const currentDate = { day: '01', month: '04', year: '2025' }
       expect(isFutureDate(currentDate)).toBe(false)
     })
 
     it('should return false if the current date matches UTC-based system time (since that will be behind BST in all cases)', () => {
-      const systemDateTime = new TZDate(
-        '2025-04-01T00:30:00',
-        'Europe/London'
-      ).withTimeZone('UTC')
-      expect(systemDateTime.toISOString()).toBe('2025-03-31T23:30:00.000+00:00')
-
-      jest.setSystemTime(systemDateTime)
+      jest.setSystemTime(
+        new TZDate('2025-04-01T00:30:00', 'Europe/London').withTimeZone('UTC')
+      )
+      expect(new Date().toISOString()).toBe('2025-03-31T23:30:00.000Z')
 
       const currentDate = { day: '31', month: '03', year: '2025' }
       expect(isFutureDate(currentDate)).toBe(false)
@@ -102,11 +96,10 @@ describe('Date Helpers', () => {
     })
 
     it('should return 0 if the given date when coverted to UTC is actually the current date', () => {
-      const systemDateTime = new TZDate(
-        '2025-04-01T00:30:00',
-        'Europe/London'
-      ).withTimeZone('UTC')
-      expect(systemDateTime.toISOString()).toBe('2025-03-31T23:30:00.000+00:00')
+      jest.setSystemTime(
+        new TZDate('2025-04-01T00:30:00', 'Europe/London').withTimeZone('UTC')
+      )
+      expect(new Date().toISOString()).toBe('2025-03-31T23:30:00.000Z')
 
       const currentDate = { day: '01', month: '04', year: '2025' }
       const difference = differenceInDaysWithToday(currentDate)
@@ -114,11 +107,10 @@ describe('Date Helpers', () => {
     })
 
     it('should return 1 if the given date when coverted to BST is one day after UTC current date', () => {
-      const systemDateTime = new TZDate(
-        '2025-04-01T00:30:00',
-        'Europe/London'
-      ).withTimeZone('UTC')
-      expect(systemDateTime.toISOString()).toBe('2025-03-31T23:30:00.000+00:00')
+      jest.setSystemTime(
+        new TZDate('2025-04-01T00:30:00', 'Europe/London').withTimeZone('UTC')
+      )
+      expect(new Date().toISOString()).toBe('2025-03-31T23:30:00.000Z')
 
       const currentDate = { day: '31', month: '03', year: '2025' }
       const difference = differenceInDaysWithToday(currentDate)

--- a/src/server/common/model/answer/date/date-utils.test.js
+++ b/src/server/common/model/answer/date/date-utils.test.js
@@ -95,7 +95,7 @@ describe('Date Helpers', () => {
       expect(difference).toBe(0)
     })
 
-    it('should return 0 if the given date when coverted to BST is actually the current date', () => {
+    it('should return 0 if the given date is actually the current date (when both are converted to BST)', () => {
       jest.setSystemTime(
         new TZDate('2025-04-01T00:30:00', 'Europe/London').withTimeZone('UTC')
       )
@@ -106,7 +106,7 @@ describe('Date Helpers', () => {
       expect(difference).toBe(0)
     })
 
-    it('should return 1 if the given date when coverted to BST before the current date', () => {
+    it('should return 1 if the given date is before the current date (when both are converted to BST)', () => {
       jest.setSystemTime(
         new TZDate('2025-04-01T00:30:00', 'Europe/London').withTimeZone('UTC')
       )

--- a/src/server/common/model/answer/date/date-utils.test.js
+++ b/src/server/common/model/answer/date/date-utils.test.js
@@ -95,7 +95,7 @@ describe('Date Helpers', () => {
       expect(difference).toBe(0)
     })
 
-    it('should return 0 if the given date when coverted to UTC is actually the current date', () => {
+    it('should return 0 if the given date when coverted to BST is actually the current date', () => {
       jest.setSystemTime(
         new TZDate('2025-04-01T00:30:00', 'Europe/London').withTimeZone('UTC')
       )
@@ -106,7 +106,7 @@ describe('Date Helpers', () => {
       expect(difference).toBe(0)
     })
 
-    it('should return 1 if the given date when coverted to BST is one day after UTC current date', () => {
+    it('should return 1 if the given date when coverted to BST before the current date', () => {
       jest.setSystemTime(
         new TZDate('2025-04-01T00:30:00', 'Europe/London').withTimeZone('UTC')
       )

--- a/src/server/common/model/answer/date/date-utils.test.js
+++ b/src/server/common/model/answer/date/date-utils.test.js
@@ -95,7 +95,7 @@ describe('Date Helpers', () => {
       expect(difference).toBe(0)
     })
 
-    it('should return 0 if the given date is actually the current date (when both are converted to BST)', () => {
+    it('should return 0 if the given date is actually the current date (when compared on the basis of BST)', () => {
       jest.setSystemTime(
         new TZDate('2025-04-01T00:30:00', 'Europe/London').withTimeZone('UTC')
       )
@@ -106,7 +106,7 @@ describe('Date Helpers', () => {
       expect(difference).toBe(0)
     })
 
-    it('should return 1 if the given date is before the current date (when both are converted to BST)', () => {
+    it('should return 1 if the given date is before the current date (when compared on the basis of BST)', () => {
       jest.setSystemTime(
         new TZDate('2025-04-01T00:30:00', 'Europe/London').withTimeZone('UTC')
       )

--- a/src/server/common/model/answer/date/date-utils.test.js
+++ b/src/server/common/model/answer/date/date-utils.test.js
@@ -28,7 +28,7 @@ describe('Date Helpers', () => {
   describe('isFutureDate', () => {
     beforeEach(() => {
       jest.useFakeTimers()
-      jest.setSystemTime(new TZDate('2025-04-01T00:00:00', 'Europe/London'))
+      jest.setSystemTime(new TZDate('2025-04-01T00:00:00+01:00'))
     })
 
     afterAll(jest.useRealTimers)
@@ -50,7 +50,7 @@ describe('Date Helpers', () => {
 
     it('should return false if current date matches in BST, even UTC-based system time is showing the previous day', () => {
       jest.setSystemTime(
-        new TZDate('2025-04-01T00:30:00', 'Europe/London').withTimeZone('UTC')
+        new TZDate('2025-04-01T00:30:00+01:00').withTimeZone('UTC')
       )
       expect(new Date().toISOString()).toBe('2025-03-31T23:30:00.000Z')
 
@@ -60,7 +60,7 @@ describe('Date Helpers', () => {
 
     it('should return false if the current date matches UTC-based system time (since that will be behind BST in all cases)', () => {
       jest.setSystemTime(
-        new TZDate('2025-04-01T00:30:00', 'Europe/London').withTimeZone('UTC')
+        new TZDate('2025-04-01T00:30:00+01:00').withTimeZone('UTC')
       )
       expect(new Date().toISOString()).toBe('2025-03-31T23:30:00.000Z')
 
@@ -72,7 +72,7 @@ describe('Date Helpers', () => {
   describe('differenceInDaysWithToday', () => {
     beforeEach(() => {
       jest.useFakeTimers()
-      jest.setSystemTime(new TZDate('2025-04-01T00:00:00', 'Europe/London'))
+      jest.setSystemTime(new TZDate('2025-04-01T00:00:00+01:00'))
     })
 
     afterAll(jest.useRealTimers)
@@ -97,7 +97,7 @@ describe('Date Helpers', () => {
 
     it('should return 0 if the given date is actually the current date (when compared on the basis of BST)', () => {
       jest.setSystemTime(
-        new TZDate('2025-04-01T00:30:00', 'Europe/London').withTimeZone('UTC')
+        new TZDate('2025-04-01T00:30:00+01:00').withTimeZone('UTC')
       )
       expect(new Date().toISOString()).toBe('2025-03-31T23:30:00.000Z')
 
@@ -108,7 +108,7 @@ describe('Date Helpers', () => {
 
     it('should return 1 if the given date is before the current date (when compared on the basis of BST)', () => {
       jest.setSystemTime(
-        new TZDate('2025-04-01T00:30:00', 'Europe/London').withTimeZone('UTC')
+        new TZDate('2025-04-01T00:30:00+01:00').withTimeZone('UTC')
       )
       expect(new Date().toISOString()).toBe('2025-03-31T23:30:00.000Z')
 


### PR DESCRIPTION
We want our date comparisons to:

- always represent the date submitted by the user as though it's a Europe/London date (e.g. accounting for BST in the summer months)
- no matter what timezone the system time is set to, use the date it would be in `Europe/London` at that point in time as our point of comparison

 I think these tests help to capture that coverage more accurately - and they've shown that a simpler implementation can have the desired effect.