### PR TITLE
BAU: fix DEFRA OIDC logging

### DIFF
--- a/src/server/common/helpers/auth/defra-id.js
+++ b/src/server/common/helpers/auth/defra-id.js
@@ -20,8 +20,7 @@ const defraId = {
       await server.register(bell)
 
       server.logger.info(
-        'Fetching IdP configuration from',
-        oidcConfigurationUrl
+        `Fetching IdP configuration from ${oidcConfigurationUrl}`
       )
 
       const response = await Wreck.get(oidcConfigurationUrl, {


### PR DESCRIPTION
The pino library expects either:

- a string *or*
- a context object followed by a string

The logging statement - as was - caused the first part to be output, but never output the OIDC url that was being used.