### PR TITLE
DSFAAP-1389: add explanation option to full name & create repsonsible person for visit premises page

### DIFF
--- a/prompts/question-type-prompt.js
+++ b/prompts/question-type-prompt.js
@@ -2,5 +2,13 @@ export const questionTypePrompt = {
   type: 'list',
   name: 'questionType',
   message: 'What \x1b[33mtype\x1b[0m of question are you adding?',
-  choices: ['checkbox', 'number', 'radio-button', 'text', 'text-area', 'date']
+  choices: [
+    'checkbox',
+    'number',
+    'radio-button',
+    'text',
+    'text-area',
+    'date',
+    'full-name'
+  ]
 }

--- a/src/server/common/model/answer/full-name/full-name.js
+++ b/src/server/common/model/answer/full-name/full-name.js
@@ -8,7 +8,7 @@ import { escapeHtml } from '../../../helpers/escape-text.js'
 
 /**
  * @typedef {{
- *  explanationText?: string,
+ *  explanation?: string,
  *  validation: {
  *    firstName: {
  *      empty?: { message: string },
@@ -119,8 +119,8 @@ export class FullNameAnswer extends AnswerModel {
   viewModel({ validate, question }) {
     const viewModel = { value: this.value, question }
 
-    if (this.config.explanationText) {
-      viewModel.explanationText = this.config.explanationText
+    if (this.config.explanation) {
+      viewModel.explanation = this.config.explanation
     }
 
     if (validate) {

--- a/src/server/common/model/answer/full-name/full-name.js
+++ b/src/server/common/model/answer/full-name/full-name.js
@@ -8,6 +8,7 @@ import { escapeHtml } from '../../../helpers/escape-text.js'
 
 /**
  * @typedef {{
+ *  explanationText?: string,
  *  validation: {
  *    firstName: {
  *      empty?: { message: string },
@@ -117,6 +118,10 @@ export class FullNameAnswer extends AnswerModel {
    */
   viewModel({ validate, question }) {
     const viewModel = { value: this.value, question }
+
+    if (this.config.explanationText) {
+      viewModel.explanationText = this.config.explanationText
+    }
 
     if (validate) {
       viewModel.errors = this.validate().errors

--- a/src/server/common/model/answer/full-name/full-name.njk
+++ b/src/server/common/model/answer/full-name/full-name.njk
@@ -13,6 +13,9 @@
     }
   })
 %}
+  {% if viewModel.explanationText %}
+    <p class="govuk-body">{{ viewModel.explanationText }}</p>
+  {% endif %}
   {{
     govukInput
     ({

--- a/src/server/common/model/answer/full-name/full-name.njk
+++ b/src/server/common/model/answer/full-name/full-name.njk
@@ -13,8 +13,8 @@
     }
   })
 %}
-  {% if viewModel.explanationText %}
-    <p class="govuk-body">{{ viewModel.explanationText }}</p>
+  {% if viewModel.explanation %}
+    <p class="govuk-body">{{ viewModel.explanation }}</p>
   {% endif %}
   {{
     govukInput

--- a/src/server/common/model/answer/full-name/full-name.test.js
+++ b/src/server/common/model/answer/full-name/full-name.test.js
@@ -3,7 +3,7 @@ import { FullNameAnswer } from './full-name.js'
 /** @import {FullNameConfig} from '../full-name/full-name.js' */
 
 const maxLength = 50
-const explanationText = 'test hint'
+const explanation = 'test hint'
 
 const validFullNamePayload = {
   firstName: 'Jean-Luc',
@@ -11,7 +11,7 @@ const validFullNamePayload = {
 }
 
 const testConfig = {
-  explanationText,
+  explanation,
   validation: {
     firstName: {
       empty: {
@@ -164,7 +164,7 @@ describe('FullName.viewModel', () => {
     expect(name.viewModel({ validate: false, question })).toEqual({
       value: name.value,
       question,
-      explanationText
+      explanation
     })
   })
 
@@ -173,7 +173,7 @@ describe('FullName.viewModel', () => {
       value: name.value,
       errors: name.validate().errors,
       question,
-      explanationText
+      explanation
     })
   })
 })

--- a/src/server/common/model/answer/full-name/full-name.test.js
+++ b/src/server/common/model/answer/full-name/full-name.test.js
@@ -3,6 +3,7 @@ import { FullNameAnswer } from './full-name.js'
 /** @import {FullNameConfig} from '../full-name/full-name.js' */
 
 const maxLength = 50
+const explanationText = 'test hint'
 
 const validFullNamePayload = {
   firstName: 'Jean-Luc',
@@ -10,6 +11,7 @@ const validFullNamePayload = {
 }
 
 const testConfig = {
+  explanationText,
   validation: {
     firstName: {
       empty: {
@@ -161,7 +163,8 @@ describe('FullName.viewModel', () => {
   it('should return the value without errors (if validate is false)', () => {
     expect(name.viewModel({ validate: false, question })).toEqual({
       value: name.value,
-      question
+      question,
+      explanationText
     })
   })
 
@@ -169,7 +172,8 @@ describe('FullName.viewModel', () => {
     expect(name.viewModel({ validate: true, question })).toEqual({
       value: name.value,
       errors: name.validate().errors,
-      question
+      question,
+      explanationText
     })
   })
 })

--- a/src/server/exotics/licence/email-or-post/index.js
+++ b/src/server/exotics/licence/email-or-post/index.js
@@ -1,0 +1,8 @@
+import { Page } from '~/src/server/common/model/page/page-model.js'
+
+// STUB PAGE
+export class EmailOrPostPage extends Page {
+  urlPath = '/exotics/receiving-the-licence/email-or-post'
+}
+
+export const emailOrPostPage = new EmailOrPostPage()

--- a/src/server/exotics/licence/visit-responsible-person-name/__snapshots__/index.test.js.snap
+++ b/src/server/exotics/licence/visit-responsible-person-name/__snapshots__/index.test.js.snap
@@ -1,0 +1,41 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`VisitResponsiblePersonNamePage content should render expected response and content 1`] = `
+"
+    <form method="POST" novalidate="">
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+          <input type="hidden" name="crumb" value="csrf-value">
+          <input type="hidden" name="nextPage" value="">
+
+<fieldset class="govuk-fieldset">
+  <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+    <h1 class="govuk-fieldset__heading">
+      Who is responsible for the premises where the visit is happening?
+    </h1>
+  </legend>
+    <p class="govuk-body">This is the person we will issue the licence to</p>
+  <div class="govuk-form-group">
+  <label class="govuk-label" for="firstName">
+    First name
+  </label>
+  <input class="govuk-input govuk-input--width-20" id="firstName" name="firstName" type="text">
+</div>
+
+  <div class="govuk-form-group">
+  <label class="govuk-label" for="lastName">
+    Last name
+  </label>
+  <input class="govuk-input govuk-input--width-20" id="lastName" name="lastName" type="text">
+</div>
+
+
+</fieldset>
+            <button type="submit" class="govuk-button" data-module="govuk-button" id="continue-button">
+  Continue
+</button>
+        </div>
+      </div>
+    </form>
+        "
+`;

--- a/src/server/exotics/licence/visit-responsible-person-name/__snapshots__/index.test.js.snap
+++ b/src/server/exotics/licence/visit-responsible-person-name/__snapshots__/index.test.js.snap
@@ -14,7 +14,7 @@ exports[`VisitResponsiblePersonNamePage content should render expected response 
       Who is responsible for the premises where the visit is happening?
     </h1>
   </legend>
-    <p class="govuk-body">This is the person we will issue the licence to</p>
+    <p class="govuk-body">This is the person we will issue the licence to.</p>
   <div class="govuk-form-group">
   <label class="govuk-label" for="firstName">
     First name

--- a/src/server/exotics/licence/visit-responsible-person-name/index.js
+++ b/src/server/exotics/licence/visit-responsible-person-name/index.js
@@ -11,7 +11,7 @@ const questionKey = 'visitResponsiblePersonName'
 export class Answer extends FullNameAnswer {
   /** @type { FullNameConfig } */
   static config = {
-    explanation: 'This is the person we will issue the licence to',
+    explanation: 'This is the person we will issue the licence to.',
     validation: {
       firstName: {
         empty: {

--- a/src/server/exotics/licence/visit-responsible-person-name/index.js
+++ b/src/server/exotics/licence/visit-responsible-person-name/index.js
@@ -1,0 +1,50 @@
+import { QuestionPage } from '~/src/server/common/model/page/question-page-model.js'
+import { ExoticsQuestionPageController } from '~/src/server/exotics/question-page-controller.js'
+import { FullNameAnswer } from '~/src/server/common/model/answer/full-name/full-name.js'
+import { emailOrPostPage } from '../email-or-post/index.js'
+
+/** @import { FullNameConfig } from '~/src/server/common/model/answer/full-name/full-name.js' */
+/** @import { ServerRegisterPluginObject } from '@hapi/hapi' */
+
+const questionKey = 'visitResponsiblePersonName'
+
+export class Answer extends FullNameAnswer {
+  /** @type { FullNameConfig } */
+  static config = {
+    explanationText: 'This is the person we will issue the licence to',
+    validation: {
+      firstName: {
+        empty: {
+          message: 'Enter a first name'
+        }
+      },
+      lastName: {
+        empty: {
+          message: 'Enter a last name'
+        }
+      }
+    }
+  }
+}
+
+export class VisitResponsiblePersonNamePage extends QuestionPage {
+  urlPath = '/exotics/receiving-the-licence/visit/responsible-person-name'
+
+  questionKey = questionKey
+  sectionKey = 'licence'
+  question = 'Who is responsible for the premises where the visit is happening?'
+
+  Answer = Answer
+
+  nextPage() {
+    return emailOrPostPage
+  }
+}
+
+export const visitResponsiblePersonNamePage =
+  new VisitResponsiblePersonNamePage()
+
+/** @satisfies {ServerRegisterPluginObject<void>} */
+export const visitResponsiblePersonName = new ExoticsQuestionPageController(
+  visitResponsiblePersonNamePage
+).plugin()

--- a/src/server/exotics/licence/visit-responsible-person-name/index.js
+++ b/src/server/exotics/licence/visit-responsible-person-name/index.js
@@ -11,7 +11,7 @@ const questionKey = 'visitResponsiblePersonName'
 export class Answer extends FullNameAnswer {
   /** @type { FullNameConfig } */
   static config = {
-    explanationText: 'This is the person we will issue the licence to',
+    explanation: 'This is the person we will issue the licence to',
     validation: {
       firstName: {
         empty: {

--- a/src/server/exotics/licence/visit-responsible-person-name/index.test.js
+++ b/src/server/exotics/licence/visit-responsible-person-name/index.test.js
@@ -1,0 +1,66 @@
+import { describePageSnapshot } from '~/src/server/common/test-helpers/snapshot-page.js'
+import { Answer, visitResponsiblePersonNamePage } from './index.js'
+import { FullNameAnswer } from '~/src/server/common/model/answer/full-name/full-name.js'
+import { EmailOrPostPage } from '../email-or-post/index.js'
+
+const sectionKey = 'licence'
+const questionKey = 'visitResponsiblePersonName'
+const pageUrl = '/exotics/receiving-the-licence/visit/responsible-person-name'
+const page = visitResponsiblePersonNamePage
+const question =
+  'Who is responsible for the premises where the visit is happening?'
+
+const payload = {
+  firstName: 'some first name',
+  lastName: 'some surname'
+}
+
+describe('Answer', () => {
+  it('should be a Full name input', () => {
+    expect(new Answer(payload)).toBeInstanceOf(FullNameAnswer)
+  })
+
+  it('should have the right validation options', () => {
+    expect(Answer.config.validation.firstName.empty?.message).toBe(
+      'Enter a first name'
+    )
+    expect(Answer.config.validation.lastName.empty?.message).toBe(
+      'Enter a last name'
+    )
+  })
+})
+
+describe('VisitResponsiblePersonNamePage', () => {
+  it('should have the correct urlPath', () => {
+    expect(page.urlPath).toBe(pageUrl)
+  })
+
+  it('should have the correct sectionKey', () => {
+    expect(page.sectionKey).toBe(sectionKey)
+  })
+
+  it('should have the correct questionKey', () => {
+    expect(page.questionKey).toBe(questionKey)
+  })
+
+  it('should have the correct question', () => {
+    expect(page.question).toBe(question)
+  })
+
+  it('should have the correct Answer model', () => {
+    expect(page.Answer).toBe(Answer)
+  })
+
+  describe('nextPage', () => {
+    it('should return EmailOrPostPage for any value', () => {
+      const nextPage = page.nextPage()
+      expect(nextPage).toBeInstanceOf(EmailOrPostPage)
+    })
+  })
+
+  describePageSnapshot({
+    describes: 'content',
+    it: 'should render expected response and content',
+    pageUrl
+  })
+})

--- a/src/server/router.js
+++ b/src/server/router.js
@@ -17,6 +17,7 @@ import { config } from '../config/config.js'
 import { ExoticsApplicationModel } from './exotics/application.js'
 import { exoticsTaskList } from './exotics/task-list/index.js'
 import { inRpaRegisteredField } from './exotics/location-of-visit/in-rpa-registered-field/index.js'
+import { visitResponsiblePersonName } from './exotics/licence/visit-responsible-person-name/index.js'
 
 /**
  * @satisfies {ServerRegisterPluginObject<void>}
@@ -67,6 +68,9 @@ export const router = {
 
         // TODO: remove this when location of the visit section for exotics is implemented and move it to that section
         await server.register([inRpaRegisteredField])
+
+        // TODO: remove this when Receiving the licence section for exotics is implemented and move it to that section
+        await server.register([visitResponsiblePersonName])
 
         await server.register(
           ExoticsApplicationModel.implementedSections.map(


### PR DESCRIPTION
There is no concept of a 'hint' in a fieldset within the [GDS design system](https://design-system.service.gov.uk/components/fieldset/).

Instead, I've added text as a paragraph (and cleared this with Anita & Guy) underneath the heading. 

Because this is not a true hint (e.g. for accessibility purposes), I've called this an 'explanation' to avoid confusion.