### PR TITLE
DSFAAP-1427: add prototype mode & prototype mode banner

### DIFF
--- a/src/config/config.js
+++ b/src/config/config.js
@@ -346,6 +346,12 @@ export const config = convict({
       format: Boolean,
       default: !isProduction,
       env: 'EXOTICS_JOURNEY_ENABLED'
+    },
+    prototypeMode: {
+      doc: 'Feature flag to turn the service into prototype mode for user research purposes',
+      format: Boolean,
+      default: false,
+      env: 'PROTOTYPE_MODE_ENABLED'
     }
   },
   caseManagementApi: {

--- a/src/config/nunjucks/context/context.test.js
+++ b/src/config/nunjucks/context/context.test.js
@@ -46,7 +46,8 @@ describe('#context', () => {
           emailConfirmation: true,
           exoticsJourney: true,
           pdfUpload: true,
-          sendToCaseManagement: true
+          sendToCaseManagement: true,
+          prototypeMode: false
         },
         uuid: 'unique-identifier',
         displayName: undefined,
@@ -152,7 +153,8 @@ describe('#context cache', () => {
           emailConfirmation: true,
           exoticsJourney: true,
           pdfUpload: true,
-          sendToCaseManagement: true
+          sendToCaseManagement: true,
+          prototypeMode: false
         },
         uuid: 'unique-identifier',
         getAssetPath: expect.any(Function),

--- a/src/server/common/helpers/start-server.test.js
+++ b/src/server/common/helpers/start-server.test.js
@@ -85,7 +85,7 @@ describe('#startServer', () => {
       )
       expect(mockHapiLoggerInfo).toHaveBeenNthCalledWith(
         4,
-        `Feature flags configuration: {"pdfUpload":true,"authEnabled":false,"authRequired":true,"emailConfirmation":true,"sendToCaseManagement":true,"exoticsJourney":true}`
+        `Feature flags configuration: {"pdfUpload":true,"authEnabled":false,"authRequired":true,"emailConfirmation":true,"sendToCaseManagement":true,"exoticsJourney":true,"prototypeMode":false}`
       )
     })
   })

--- a/src/server/common/templates/layouts/page.njk
+++ b/src/server/common/templates/layouts/page.njk
@@ -29,14 +29,25 @@
   {{ pageTitle }}
 {% endblock %}
 {% block beforeContent %}
-  {{
-    govukPhaseBanner({
-      tag: {
-        text: 'Beta'
-      },
-      html: 'This is a new service. Help us improve it and <a data-testid="feedback-link" target="_blank" class="govuk-link" href="https://defragroup.eu.qualtrics.com/jfe/form/SV_7ZDFNwIA2wLF9lk">give your feedback (opens in new tab)</a>.'
-    })
-  }}
+  {% if features.prototypeMode %}
+    {{
+      govukPhaseBanner({
+        tag: {
+          text: 'Prototype'
+        },
+        html: 'This is a service prototype.'
+      })
+    }}
+  {% else %}
+    {{
+      govukPhaseBanner({
+        tag: {
+          text: 'Beta'
+        },
+        html: 'This is a new service. Help us improve it and <a data-testid="feedback-link" target="_blank" class="govuk-link" href="https://defragroup.eu.qualtrics.com/jfe/form/SV_7ZDFNwIA2wLF9lk">give your feedback (opens in new tab)</a>.'
+      })
+    }}
+  {% endif %}
   {% if breadcrumbs.length > 1 %}
     {{
       appBreadcrumbs({

--- a/src/server/exotics/task-list/index.test.js
+++ b/src/server/exotics/task-list/index.test.js
@@ -2,6 +2,12 @@ import { describePageSnapshot } from '../../common/test-helpers/snapshot-page.js
 import { ExoticsApplicationModel } from '../application.js'
 import { ExoticsStateManager } from '../state-manager.js'
 import { ExoticsTaskListController } from './index.js'
+import { createServer } from '../../index.js'
+import { withCsrfProtection } from '../../common/test-helpers/csrf.js'
+import { parseDocument } from '../../common/test-helpers/dom.js'
+import { spyOnConfig } from '../../common/test-helpers/config.js'
+
+/** @import { Server } from '@hapi/hapi' */
 
 describe('ExoticsTaskListController', () => {
   const controller = new ExoticsTaskListController()
@@ -32,5 +38,42 @@ describe('ExoticsTaskListController', () => {
     describes: 'ExoticsTaskListController',
     it: 'should have the expected content',
     pageUrl: controller.urlPath
+  })
+
+  describe('task list banner', () => {
+    /** @type {Server} */
+    let server
+
+    beforeAll(async () => {
+      server = await createServer()
+      await server.initialize()
+    })
+
+    afterAll(async () => {
+      await server.stop({ timeout: 0 })
+    })
+
+    it('should have the right banner (in protype mode)', async () => {
+      spyOnConfig('featureFlags', {
+        prototypeMode: true
+      })
+
+      const { payload } = await server.inject(
+        withCsrfProtection({
+          method: 'GET',
+          url: controller.urlPath
+        })
+      )
+
+      const contentTag = parseDocument(payload)
+        .querySelector('.govuk-phase-banner__content__tag')
+        ?.innerHTML.trim()
+      const text = parseDocument(payload)
+        .querySelector('.govuk-phase-banner__text')
+        ?.innerHTML.trim()
+
+      expect(contentTag).toBe('Prototype')
+      expect(text).toBe('This is a service prototype.')
+    })
   })
 })


### PR DESCRIPTION
Note that the **existing** banner text is covered by the user journeys - so in this case I've added an indicative test for the prototype mode version only.