### PR TITLE
[1754] support an option for 'none' in checkbox answer model

### DIFF
--- a/src/server/common/model/answer/checkbox/checkbox.js
+++ b/src/server/common/model/answer/checkbox/checkbox.js
@@ -30,7 +30,11 @@ const createCheckboxSchema = (config) => {
 }
 
 /**
- * @typedef {{ label: string }} CheckboxOption
+ * @typedef {{
+ *   label: string,
+ *   exclusive?: boolean
+ * }} CheckboxOption
+ *
  * @typedef {{
  *   payloadKey: string,
  *   options: Record<string, CheckboxOption>,
@@ -123,14 +127,28 @@ export class CheckboxAnswer extends AnswerModel {
           isPageHeading
         }
       },
-      items: Object.entries(options).map(([value, option]) => ({
-        text: option.label,
-        value,
-        attributes: {
-          'data-testid': `${value}-checkbox`
-        },
-        checked: (values ?? []).includes(value)
-      }))
+      items: Object.entries(options).map(([value, option]) => {
+        if (value === 'divider') {
+          return {
+            divider: option.label
+          }
+        }
+
+        const checkboxOption = {
+          text: option.label,
+          value,
+          attributes: {
+            'data-testid': `${value}-checkbox`
+          },
+          checked: (values ?? []).includes(value)
+        }
+
+        if (option.exclusive) {
+          checkboxOption.behaviour = 'exclusive'
+        }
+
+        return checkboxOption
+      })
     }
 
     if (hint) {

--- a/src/server/common/model/answer/checkbox/checkbox.test.js
+++ b/src/server/common/model/answer/checkbox/checkbox.test.js
@@ -299,3 +299,62 @@ describe('CheckboxAnswer.viewModel', () => {
     })
   })
 })
+
+describe('CheckboxAnswer - dividers and exclusive options', () => {
+  const configWithDividerAndExclusive = {
+    payloadKey: 'test_checkbox',
+    options: {
+      option1: { label: 'Option 1' },
+      divider: { label: 'Divider label' },
+      option2: { label: 'Option 2', exclusive: true }
+    },
+    validation: {}
+  }
+
+  class DividerExclusiveCheckboxAnswer extends CheckboxAnswer {
+    static config = configWithDividerAndExclusive
+  }
+
+  it('should include a divider item in the viewModel', async () => {
+    const answer = new DividerExclusiveCheckboxAnswer({ test_checkbox: [] })
+    const viewModel = await answer.viewModel({
+      question: 'Test',
+      validate: false
+    })
+    expect(viewModel.items).toEqual([
+      {
+        text: 'Option 1',
+        value: 'option1',
+        attributes: { 'data-testid': 'option1-checkbox' },
+        checked: false
+      },
+      {
+        divider: 'Divider label'
+      },
+      {
+        text: 'Option 2',
+        value: 'option2',
+        attributes: { 'data-testid': 'option2-checkbox' },
+        checked: false,
+        behaviour: 'exclusive'
+      }
+    ])
+  })
+
+  it('should mark exclusive options with behaviour: "exclusive"', async () => {
+    const answer = new DividerExclusiveCheckboxAnswer({
+      test_checkbox: ['option2']
+    })
+    const viewModel = await answer.viewModel({
+      question: 'Test',
+      validate: false
+    })
+    const exclusiveItem = viewModel.items.find(
+      (item) => 'value' in item && item.value === 'option2'
+    )
+    expect(exclusiveItem).toMatchObject({
+      behaviour: 'exclusive',
+      checked: true
+    })
+  })
+})


### PR DESCRIPTION
To support the divider and "none" option add items in the config for answer

Divider:
```
{
  ...,
  divider: {
    label: 'or'
  },
  ...
}
```

To add a "none", or rather `exclusive`, option

```
{
  ...,
  [noneValue]: {
    label: 'Or nothing at all',
    exclusive: true
  },
  ...
}
```

This then uses the already provided support in the GDS component for this behaviour
