### PR TITLE
BAU: enable full unit tests on pull request

### DIFF
--- a/.github/workflows/check-pull-request.yml
+++ b/.github/workflows/check-pull-request.yml
@@ -60,7 +60,10 @@ jobs:
           npm run build
           npm run format:check
           npm run lint
-          npm test
+          npm run test -- --projects jest-projects/core.js
+          npm run test -- --projects jest-projects/fmd.js
+          npm run test -- --projects jest-projects/exotics.js
+          npm run test -- --projects jest-projects/tb.js
 
       - name: SonarCloud Scan
         if: github.actor != 'dependabot[bot]'

--- a/.github/workflows/check-pull-request.yml
+++ b/.github/workflows/check-pull-request.yml
@@ -60,7 +60,7 @@ jobs:
           npm run build
           npm run format:check
           npm run lint
-          npm test -- --changedSince="origin/${{ github.base_ref }}"
+          npm test
 
       - name: SonarCloud Scan
         if: github.actor != 'dependabot[bot]'


### PR DESCRIPTION
In previous months, we were making 5+ updates to this repo per day
amongst 3 team members.  In that context, the full unit test suite
was getting in the way.

Now the pace has decreased, a greater proportion of our PRs are made
up by things - like version updates - that will not get caught by
those checks.  And we're less impeded overall by a longer PR run (since
we're not running so hot as a collective)