### PR TITLE
Fix brittle GOV.UK guidance link selector on fifty percent warning page

### DIFF
--- a/user-journey-tests/TB/page-objects/origin/fiftyPercentWarningPage.js
+++ b/user-journey-tests/TB/page-objects/origin/fiftyPercentWarningPage.js
@@ -9,7 +9,9 @@ class FiftyPercentWarningPage extends Page {
   pageTitle = pageHeadingAndTitle
 
   get getYourCattleTestedLink() {
-    return $('a=GOV.UK Bovine TB guidance page (opens in new tab)')
+    // Partial match: the "(opens in new tab)" text sits outside the <a>, so an
+    // exact link-text selector would never match the anchor's own text.
+    return $('a*=GOV.UK Bovine TB guidance page')
   }
 
   async verifyGetYourCattleTestedLink() {


### PR DESCRIPTION
The exact link-text selector required the anchor's own text to equal "GOV.UK Bovine TB guidance page (opens in new tab)", but the template renders "(opens in new tab)" outside the <a>, so the anchor text is only "GOV.UK Bovine TB guidance page". Use a partial match so the BrowserStack test reliably finds the link.

The recent dependency changes was causing the brittle selector to fail.

Here is the Browserstack run for this branch: https://github.com/DEFRA/apha-apps-perms-move-animal-ui/actions/runs/26646748163