### PR TITLE
Update privacy notice links

### DIFF
--- a/src/server/exotics/home/__snapshots__/index.test.js.snap
+++ b/src/server/exotics/home/__snapshots__/index.test.js.snap
@@ -44,7 +44,7 @@ exports[`HomePage HomePage content checks when auth is disabled should match con
         <h3 class="govuk-heading-m">Using and sharing your information</h3>
         <p class="govuk-body">
           How we use your personal data is set out in the
-          <a href="https://www.gov.uk/government/publications/animal-and-plant-heath-agency-privacy-notices/exotic-notifiable-and-reportable-diseases-privacy-notice#:~:text=APHA%20may%20share%20data%20with,is%20identified%20at%20the%20laboratory." class="govuk-link" target="_blank">exotic, notifiable and reportable diseases privacy notice (opens in
+          <a href="https://www.gov.uk/government/publications/animal-and-plant-health-agency-privacy-notices/exotic-notifiable-and-reportable-diseases-privacy-notice#:~:text=APHA%20may%20share%20data%20with,is%20identified%20at%20the%20laboratory." class="govuk-link" target="_blank">exotic, notifiable and reportable diseases privacy notice (opens in
             a new tab)</a>
           .
         </p>
@@ -112,7 +112,7 @@ exports[`HomePage HomePage content checks when auth is enabled should match cont
         <h3 class="govuk-heading-m">Using and sharing your information</h3>
         <p class="govuk-body">
           How we use your personal data is set out in the
-          <a href="https://www.gov.uk/government/publications/animal-and-plant-heath-agency-privacy-notices/exotic-notifiable-and-reportable-diseases-privacy-notice#:~:text=APHA%20may%20share%20data%20with,is%20identified%20at%20the%20laboratory." class="govuk-link" target="_blank">exotic, notifiable and reportable diseases privacy notice (opens in
+          <a href="https://www.gov.uk/government/publications/animal-and-plant-health-agency-privacy-notices/exotic-notifiable-and-reportable-diseases-privacy-notice#:~:text=APHA%20may%20share%20data%20with,is%20identified%20at%20the%20laboratory." class="govuk-link" target="_blank">exotic, notifiable and reportable diseases privacy notice (opens in
             a new tab)</a>
           .
         </p>

--- a/src/server/exotics/home/index.njk
+++ b/src/server/exotics/home/index.njk
@@ -56,7 +56,7 @@
         <p class="govuk-body">
           How we use your personal data is set out in the
           <a
-            href="https://www.gov.uk/government/publications/animal-and-plant-heath-agency-privacy-notices/exotic-notifiable-and-reportable-diseases-privacy-notice#:~:text=APHA%20may%20share%20data%20with,is%20identified%20at%20the%20laboratory."
+            href="https://www.gov.uk/government/publications/animal-and-plant-health-agency-privacy-notices/exotic-notifiable-and-reportable-diseases-privacy-notice#:~:text=APHA%20may%20share%20data%20with,is%20identified%20at%20the%20laboratory."
             class="govuk-link"
             target="_blank"
             >exotic, notifiable and reportable diseases privacy notice (opens in

--- a/src/server/fmd/home/__snapshots__/index.test.js.snap
+++ b/src/server/fmd/home/__snapshots__/index.test.js.snap
@@ -46,7 +46,7 @@ exports[`HomePage HomePage content checks when auth is disabled should match con
         <h3 class="govuk-heading-m">Using and sharing your information</h3>
         <p class="govuk-body">
           How we use your personal data is set out in the
-          <a href="https://www.gov.uk/government/publications/animal-and-plant-heath-agency-privacy-notices/exotic-notifiable-and-reportable-diseases-privacy-notice#:~:text=APHA%20may%20share%20data%20with,is%20identified%20at%20the%20laboratory." class="govuk-link" target="_blank">exotic, notifiable and reportable diseases privacy notice (opens in
+          <a href="https://www.gov.uk/government/publications/animal-and-plant-health-agency-privacy-notices/exotic-notifiable-and-reportable-diseases-privacy-notice#:~:text=APHA%20may%20share%20data%20with,is%20identified%20at%20the%20laboratory." class="govuk-link" target="_blank">exotic, notifiable and reportable diseases privacy notice (opens in
             a new tab)</a>
           .
         </p>
@@ -111,7 +111,7 @@ exports[`HomePage HomePage content checks when auth is enabled should match cont
         <h3 class="govuk-heading-m">Using and sharing your information</h3>
         <p class="govuk-body">
           How we use your personal data is set out in the
-          <a href="https://www.gov.uk/government/publications/animal-and-plant-heath-agency-privacy-notices/exotic-notifiable-and-reportable-diseases-privacy-notice#:~:text=APHA%20may%20share%20data%20with,is%20identified%20at%20the%20laboratory." class="govuk-link" target="_blank">exotic, notifiable and reportable diseases privacy notice (opens in
+          <a href="https://www.gov.uk/government/publications/animal-and-plant-health-agency-privacy-notices/exotic-notifiable-and-reportable-diseases-privacy-notice#:~:text=APHA%20may%20share%20data%20with,is%20identified%20at%20the%20laboratory." class="govuk-link" target="_blank">exotic, notifiable and reportable diseases privacy notice (opens in
             a new tab)</a>
           .
         </p>

--- a/src/server/fmd/home/index.njk
+++ b/src/server/fmd/home/index.njk
@@ -58,7 +58,7 @@
         <p class="govuk-body">
           How we use your personal data is set out in the
           <a
-            href="https://www.gov.uk/government/publications/animal-and-plant-heath-agency-privacy-notices/exotic-notifiable-and-reportable-diseases-privacy-notice#:~:text=APHA%20may%20share%20data%20with,is%20identified%20at%20the%20laboratory."
+            href="https://www.gov.uk/government/publications/animal-and-plant-health-agency-privacy-notices/exotic-notifiable-and-reportable-diseases-privacy-notice#:~:text=APHA%20may%20share%20data%20with,is%20identified%20at%20the%20laboratory."
             class="govuk-link"
             target="_blank"
             >exotic, notifiable and reportable diseases privacy notice (opens in

--- a/src/server/privacy-policy/index.njk
+++ b/src/server/privacy-policy/index.njk
@@ -16,7 +16,7 @@
           More detailed information on how we manage personal data for each of
           our functions is included within
           <a
-            href="https://www.gov.uk/government/publications/animal-and-plant-heath-agency-privacy-notices"
+            href="https://www.gov.uk/government/publications/animal-and-plant-health-agency-privacy-notices"
             class="govuk-link"
           >
             individual privacy notices</a
@@ -68,7 +68,7 @@
         <p class="govuk-body">
           The personal data collected is made clear in
           <a
-            href="https://www.gov.uk/government/publications/animal-and-plant-heath-agency-privacy-notices"
+            href="https://www.gov.uk/government/publications/animal-and-plant-health-agency-privacy-notices"
             class="govuk-link"
           >
             individual
@@ -82,7 +82,7 @@
           How your data has been obtained in any particular case is made clear
           in
           <a
-            href="https://www.gov.uk/government/publications/animal-and-plant-heath-agency-privacy-notices"
+            href="https://www.gov.uk/government/publications/animal-and-plant-health-agency-privacy-notices"
             class="govuk-link"
           >
             individual

--- a/user-journey-tests/TB/specs/privacyPolicy.spec.js
+++ b/user-journey-tests/TB/specs/privacyPolicy.spec.js
@@ -20,21 +20,21 @@ describe('Privacy policy page test', () => {
   it('Should verify the individual privacy notices link', async () => {
     await selectElement(privacyPage.individualNoticesLink)
     await waitForPagePath(
-      '/government/publications/animal-and-plant-heath-agency-privacy-notices'
+      '/government/publications/animal-and-plant-health-agency-privacy-notices'
     )
   })
 
   it('Should verify the first individual apha privacy notices link', async () => {
     await selectElement(privacyPage.aphaNotices1)
     await waitForPagePath(
-      '/government/publications/animal-and-plant-heath-agency-privacy-notices'
+      '/government/publications/animal-and-plant-health-agency-privacy-notices'
     )
   })
 
   it('Should verify the second individual apha privacy notices link', async () => {
     await selectElement(privacyPage.aphaNotices2)
     await waitForPagePath(
-      '/government/publications/animal-and-plant-heath-agency-privacy-notices'
+      '/government/publications/animal-and-plant-health-agency-privacy-notices'
     )
   })
 


### PR DESCRIPTION
**Changes**
- Fixed typo in APHA privacy notice URLs: `heath` → `health`
- Updated journey test expectations to match corrected URLs
- Regenerated snapshot tests

I triggered the pipeline and the fix is working fine here:
- https://github.com/DEFRA/apha-apps-perms-move-animal-ui/actions/workflows/run-tests-browserstack-core.yaml
- https://github.com/DEFRA/apha-apps-perms-move-animal-ui/actions/workflows/run-tests-browserstack-mobile.yaml