### PR TITLE
Fix punctuation and update link in homepage content

### DIFF
--- a/src/server/tb/destination/contact-tb-restricted-farm/__snapshots__/index.test.js.snap
+++ b/src/server/tb/destination/contact-tb-restricted-farm/__snapshots__/index.test.js.snap
@@ -16,7 +16,7 @@ exports[`ContactTbRestrictedFarmPage ContactTbRestrictedFarmPage.content should 
         </p>
         <p>
           If the destination farm cannot apply, complete and
-          <a href="https://www.gov.uk/government/publications/tb-restricted-cattle-application-for-movement-licence-in-england" target="_blank">
+          <a href="https://www.gov.uk/government/publications/tb-movement-licence-moving-animals-between-restricted-premises-in-england" target="_blank">
             send this application form to APHA (opens in new tab)</a>.
         </p>
       </div>

--- a/src/server/tb/destination/contact-tb-restricted-farm/index.njk
+++ b/src/server/tb/destination/contact-tb-restricted-farm/index.njk
@@ -15,7 +15,7 @@
         <p>
           If the destination farm cannot apply, complete and
           <a
-            href="https://www.gov.uk/government/publications/tb-restricted-cattle-application-for-movement-licence-in-england"
+            href="https://www.gov.uk/government/publications/tb-movement-licence-moving-animals-between-restricted-premises-in-england"
             target="_blank"
           >
             send this application form to APHA (opens in new tab)</a

--- a/src/server/tb/home/__snapshots__/index.test.js.snap
+++ b/src/server/tb/home/__snapshots__/index.test.js.snap
@@ -25,7 +25,7 @@ exports[`HomePage content checks should match content 1`] = `
         <ul class="govuk-list govuk-list--bullet">
           <li>
             from an unrestricted farm or market to a TB restricted farm or
-            premises.
+            premises
           </li>
           <li>
             from a TB restricted farm or premises to:
@@ -42,7 +42,7 @@ exports[`HomePage content checks should match content 1`] = `
               <li>a dedicated TB sale (orange market)</li>
             </ul>
           </li>
-          <li>from an AFU (including AFUE) to an AFU (including AFUE).</li>
+          <li>from an AFU (including AFUE) to an AFU (including AFUE)</li>
         </ul>
         <h3 class="govuk-heading-m">When you do not need this service</h3>
         <p class="govuk-body">
@@ -71,7 +71,7 @@ exports[`HomePage content checks should match content 1`] = `
         </p>
         <p class="govuk-body">
           If the destination farm or premises cannot apply, use
-          <a href="https://www.gov.uk/government/publications/tb-restricted-cattle-application-for-movement-licence-in-england">
+          <a href="https://www.gov.uk/government/publications/tb-movement-licence-moving-animals-between-restricted-premises-in-england">
             this application form</a>
           instead.
         </p>

--- a/src/server/tb/home/index.njk
+++ b/src/server/tb/home/index.njk
@@ -27,7 +27,7 @@
         <ul class="govuk-list govuk-list--bullet">
           <li>
             from an unrestricted farm or market to a TB restricted farm or
-            premises.
+            premises
           </li>
           <li>
             from a TB restricted farm or premises to:
@@ -44,7 +44,7 @@
               <li>a dedicated TB sale (orange market)</li>
             </ul>
           </li>
-          <li>from an AFU (including AFUE) to an AFU (including AFUE).</li>
+          <li>from an AFU (including AFUE) to an AFU (including AFUE)</li>
         </ul>
         <h3 class="govuk-heading-m">When you do not need this service</h3>
         <p class="govuk-body">
@@ -74,7 +74,7 @@
         <p class="govuk-body">
           If the destination farm or premises cannot apply, use
           <a
-            href="https://www.gov.uk/government/publications/tb-restricted-cattle-application-for-movement-licence-in-england"
+            href="https://www.gov.uk/government/publications/tb-movement-licence-moving-animals-between-restricted-premises-in-england"
           >
             this application form</a
           >

--- a/src/server/tb/origin/contact-tb-restricted-farm/__snapshots__/index.test.js.snap
+++ b/src/server/tb/origin/contact-tb-restricted-farm/__snapshots__/index.test.js.snap
@@ -16,7 +16,7 @@ exports[`ContactTbRestrictedFarmPage #ContactTbRestrictedFarmPage.content should
         </p>
         <p>
           If the destination farm cannot apply, complete and
-          <a href="https://www.gov.uk/government/publications/tb-restricted-cattle-application-for-movement-licence-in-england" target="_blank">
+          <a href="https://www.gov.uk/government/publications/tb-movement-licence-moving-animals-between-restricted-premises-in-england" target="_blank">
             send this application form to APHA (opens in new tab)</a>.
         </p>
       </div>

--- a/src/server/tb/origin/contact-tb-restricted-farm/index.njk
+++ b/src/server/tb/origin/contact-tb-restricted-farm/index.njk
@@ -15,7 +15,7 @@
         <p>
           If the destination farm cannot apply, complete and
           <a
-            href="https://www.gov.uk/government/publications/tb-restricted-cattle-application-for-movement-licence-in-england"
+            href="https://www.gov.uk/government/publications/tb-movement-licence-moving-animals-between-restricted-premises-in-england"
             target="_blank"
           >
             send this application form to APHA (opens in new tab)</a

--- a/user-journey-tests/TB/page-objects/origin/originTypeExitPage.js
+++ b/user-journey-tests/TB/page-objects/origin/originTypeExitPage.js
@@ -11,14 +11,14 @@ class OriginTypeExitPage extends Page {
 
   get viewApplicationLink() {
     return $(
-      'a[href*="tb-restricted-cattle-application-for-movement-licence-in-england"]'
+      'a[href*="tb-movement-licence-moving-animals-between-restricted-premises-in-england"]'
     )
   }
 
   async verifyViewApplicationLink() {
     await page.validateHrefOfElement(
       this.viewApplicationLink,
-      'https://www.gov.uk/government/publications/tb-restricted-cattle-application-for-movement-licence-in-england'
+      'https://www.gov.uk/government/publications/tb-movement-licence-moving-animals-between-restricted-premises-in-england'
     )
   }
 }

--- a/user-journey-tests/TB/specs/landing.spec.js
+++ b/user-journey-tests/TB/specs/landing.spec.js
@@ -12,7 +12,7 @@ import signInPage from '../page-objects/signInPage.js'
 const expectedLinks = [
   'https://www.gov.uk/',
   'https://www.gov.uk/guidance/bovine-tb-get-your-cattle-tested-in-england',
-  'https://www.gov.uk/government/publications/tb-restricted-cattle-application-for-movement-licence-in-england'
+  'https://www.gov.uk/government/publications/tb-movement-licence-moving-animals-between-restricted-premises-in-england'
 ]
 describe('Landing page test', () => {
   before(async () => {


### PR DESCRIPTION
**PR Summary:**
- Updated TB movement licence application form link across the service
- Changed from old URL: `tb-restricted-cattle-application-for-movement-licence-in-england` to new URL: `tb-movement-licence-moving-animals-between-restricted-premises-in-england`
- Updated 3 page templates (destination contact page, origin contact page, and home page)
- Updated test files to expect the new URL
- Updated test snapshots to reflect the new link